### PR TITLE
fix(sidebar): convert `data-selected` prop in `SidebarItem` to be boolean only

### DIFF
--- a/src/components/Sidebar/SidebarHeader.tsx
+++ b/src/components/Sidebar/SidebarHeader.tsx
@@ -13,7 +13,7 @@ const SidebarHeader: React.FC<SidebarHeaderProps> = ({ className, ...props }) =>
   const isExpanded = isOpen || isMobileOpen;
 
   return (
-    <div {...props} className={cn('relative flex items-center justify-end p-sm', className)}>
+    <div className={cn('relative flex items-center justify-end p-sm', className)} {...props}>
       <AnimatePresence initial={false}>
         {isExpanded && (
           <Typography

--- a/src/components/Sidebar/SidebarItem.tsx
+++ b/src/components/Sidebar/SidebarItem.tsx
@@ -123,7 +123,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
             'data-[selected=true]:bg-slate-5 data-[selected=true]:hover:bg-slate-5',
           )}
           onClick={handleClick}
-          data-selected={selected}
+          data-selected={!!selected}
         >
           {href ? <a href={href}>{content}</a> : to ? <Link to={to}>{content}</Link> : content}
         </Button>


### PR DESCRIPTION
# 🚀 Summary
This PR fixes an issue where `data-selected` prop can be `undefined` instead of boolean only.

# ✏️ Changes
- Make sure `data-selected` prop to be boolean only