### PR TITLE
refactor(sidebaritem): improve type safety with discriminated unions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,4 +33,16 @@ export default defineConfig([
       'simple-import-sort/exports': 'error',
     },
   },
+
+  {
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
 ]);

--- a/src/containers/RootLayout.tsx
+++ b/src/containers/RootLayout.tsx
@@ -33,6 +33,7 @@ const RootLayout: React.FC = () => {
 
             <SidebarContent>
               <SidebarItem
+                kind="link"
                 icon={Home}
                 label="Home"
                 tooltip="Home"
@@ -40,6 +41,7 @@ const RootLayout: React.FC = () => {
                 selected={selected === '/'}
               />
               <SidebarItem
+                kind="link"
                 icon={UsersRound}
                 label="Students"
                 tooltip="Students"


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR refactors the `SidebarItem` component to use discriminated unions for improved type safety. Although this introduces an additional `kind` prop, the tradeoff is correct type propagation to the downstream component or element.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Added a new ESLint rule to allow unused variables with an underscore prefix
- Refactored `SidebarItem` to use discriminated unions