### PR TITLE
refactor(sidebaritem): revert discriminated unions in favor of exclusive props

### DIFF
--- a/src/containers/RootLayout.tsx
+++ b/src/containers/RootLayout.tsx
@@ -33,7 +33,6 @@ const RootLayout: React.FC = () => {
 
             <SidebarContent>
               <SidebarItem
-                kind="link"
                 icon={Home}
                 label="Home"
                 tooltip="Home"
@@ -41,7 +40,6 @@ const RootLayout: React.FC = () => {
                 selected={selected === '/'}
               />
               <SidebarItem
-                kind="link"
                 icon={UsersRound}
                 label="Students"
                 tooltip="Students"


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR reverts the use of discriminated unions in `SidebarItem`.

The `kind` discriminator duplicated information already conveyed by existing props (`href`, `to`, `onClick`), increasing the component’s public API surface and call-site boilerplate without providing meaningful additional safety or functionality compared to the previous `never`-based mutually exclusive approach.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Reverted to using `never`-based mutually exclusive props to keep the API simple and ergonomic
- Removed `useCallback` from `handlePointerMove` since memoization is not needed
