### PR TITLE
feat: enable code splitting with React Router lazy routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,22 +3,21 @@ import './App.css';
 import React from 'react';
 import { createBrowserRouter, RouterProvider } from 'react-router';
 
-import HomeView from './containers/HomeView';
 import RootLayout from './containers/RootLayout';
-import StudentsView from './containers/StudentsView';
 
 const router = createBrowserRouter([
   {
     path: '/',
     Component: RootLayout,
+    HydrateFallback: () => null,
     children: [
       {
         index: true,
-        Component: HomeView,
+        lazy: () => import('./containers/HomeView'),
       },
       {
         path: 'students',
-        Component: StudentsView,
+        lazy: () => import('./containers/StudentsView'),
       },
     ],
   },

--- a/src/containers/HomeView.tsx
+++ b/src/containers/HomeView.tsx
@@ -93,4 +93,4 @@ const HomeView: React.FC = () => {
   );
 };
 
-export default HomeView;
+export { HomeView as Component };

--- a/src/containers/StudentsView.tsx
+++ b/src/containers/StudentsView.tsx
@@ -8,4 +8,4 @@ const StudentsView: React.FC = () => {
   );
 };
 
-export default StudentsView;
+export { StudentsView as Component };


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR enables code splitting using React Router lazy routes. This allows us to break down the output bundle into smaller chunks and load only the required ones when needed, reducing bandwidth usage and improving initial load time.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Enabled route-based code splitting with React Router `lazy`
