### PR TITLE
feat: add support for middleware handlers and organise middleware and route registration

### DIFF
--- a/server/cmd/tw/main.go
+++ b/server/cmd/tw/main.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/String-sg/teacher-workspace/server/internal/config"
+	"github.com/String-sg/teacher-workspace/server/internal/middleware"
+	"github.com/String-sg/teacher-workspace/server/internal/routes"
 	"github.com/String-sg/teacher-workspace/server/pkg/dotenv"
 	"golang.org/x/sync/errgroup"
 )
@@ -54,14 +56,13 @@ func main() {
 func run(ctx context.Context, cfg *config.Config) error {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("Hello, World!"))
-	})
+	routes.Register(mux)
+
+	handler := middleware.Chain(mux, middleware.RequestID)
 
 	server := &http.Server{
 		Addr:              fmt.Sprintf("[::1]:%d", cfg.Server.Port),
-		Handler:           mux,
+		Handler:           handler,
 		ReadTimeout:       cfg.Server.ReadTimeout,
 		ReadHeaderTimeout: cfg.Server.ReadHeaderTimeout,
 		WriteTimeout:      cfg.Server.WriteTimeout,

--- a/server/internal/middleware/middleware.go
+++ b/server/internal/middleware/middleware.go
@@ -1,0 +1,15 @@
+package middleware
+
+import "net/http"
+
+type Middleware func(http.Handler) http.Handler
+
+// Chain applies the given middleware to the handler in order and returns the
+// resulting composed handler. Middleware are applied from left to right, so
+// the first middleware in the list is the outermost one.
+func Chain(h http.Handler, m ...Middleware) http.Handler {
+	for i := len(m) - 1; i >= 0; i-- {
+		h = m[i](h)
+	}
+	return h
+}

--- a/server/internal/middleware/middleware_test.go
+++ b/server/internal/middleware/middleware_test.go
@@ -1,0 +1,61 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/String-sg/teacher-workspace/server/pkg/require"
+)
+
+func TestChain_Order(t *testing.T) {
+	var calls []string
+
+	m1 := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, "m1-before")
+			next.ServeHTTP(w, r)
+			calls = append(calls, "m1-after")
+		})
+	}
+	m2 := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, "m2-before")
+			next.ServeHTTP(w, r)
+			calls = append(calls, "m2-after")
+		})
+	}
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, "handler")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	Chain(h, m1, m2).ServeHTTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, "m1-before,m2-before,handler,m2-after,m1-after", strings.Join(calls, ","))
+}
+
+func TestChain_NoMiddleware(t *testing.T) {
+	called := false
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	Chain(h).ServeHTTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.True(t, called)
+}

--- a/server/internal/middleware/request_id.go
+++ b/server/internal/middleware/request_id.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"log/slog"
+	"net/http"
+)
+
+type ctxKeyRequestID struct{}
+type ctxKeyLogger struct{}
+
+const requestIDHeader = "X-Request-ID"
+
+// RequestID is an HTTP middleware that generates a unique request identifier
+// for each incoming request. The request ID and a request-scoped logger
+// containing it are stored in the request context. The ID is also written to
+// the response headers to support log correlation and request tracing.
+func RequestID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := newRequestID()
+		ctx := context.WithValue(r.Context(), ctxKeyRequestID{}, id)
+
+		logger := slog.Default().With("request_id", id)
+		ctx = context.WithValue(ctx, ctxKeyLogger{}, logger)
+
+		w.Header().Set(requestIDHeader, id)
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// RequestIDFromContext retrieves the request ID from the provided context.
+// The returned boolean indicates whether a request ID was present.
+func RequestIDFromContext(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(ctxKeyRequestID{}).(string)
+	return id, ok
+}
+
+// LoggerFromContext retrieves the request-scoped logger from the provided
+// context. If no logger is present, it falls back to the default logger.
+func LoggerFromContext(ctx context.Context) *slog.Logger {
+	if logger, ok := ctx.Value(ctxKeyLogger{}).(*slog.Logger); ok {
+		return logger
+	}
+	return slog.Default()
+}
+
+func newRequestID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	return base64.RawStdEncoding.EncodeToString(b[:])
+}

--- a/server/internal/middleware/request_id_test.go
+++ b/server/internal/middleware/request_id_test.go
@@ -50,6 +50,12 @@ func TestRequestID_RequestIDFromContext(t *testing.T) {
 	require.True(t, gotOK)
 }
 
+func TestRequestID_RequestIDFromContext_NotFound(t *testing.T) {
+	id, ok := RequestIDFromContext(context.Background())
+	require.Equal(t, "", id)
+	require.False(t, ok)
+}
+
 func TestRequestID_LoggerFromContext(t *testing.T) {
 	var gotLogger *slog.Logger
 

--- a/server/internal/middleware/request_id_test.go
+++ b/server/internal/middleware/request_id_test.go
@@ -1,0 +1,76 @@
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/String-sg/teacher-workspace/server/pkg/require"
+)
+
+func TestRequestID(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	h := RequestID(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, 22, len(res.Header.Get(requestIDHeader)))
+}
+
+func TestRequestID_RequestIDFromContext(t *testing.T) {
+	var gotID string
+	var gotOK bool
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotID, gotOK = RequestIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	h := RequestID(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, 22, len(res.Header.Get(requestIDHeader)))
+	require.Equal(t, gotID, res.Header.Get(requestIDHeader))
+	require.True(t, gotOK)
+}
+
+func TestRequestID_LoggerFromContext(t *testing.T) {
+	var gotLogger *slog.Logger
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotLogger = LoggerFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	h := RequestID(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.NotEqual(t, slog.Default(), gotLogger)
+}
+
+func TestRequestID_LoggerFromContextFallback(t *testing.T) {
+	logger := LoggerFromContext(context.Background())
+	require.Equal(t, slog.Default(), logger)
+}

--- a/server/internal/routes/index.go
+++ b/server/internal/routes/index.go
@@ -1,0 +1,8 @@
+package routes
+
+import "net/http"
+
+func Index(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("Hello, World!"))
+}

--- a/server/internal/routes/index_test.go
+++ b/server/internal/routes/index_test.go
@@ -1,0 +1,20 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/String-sg/teacher-workspace/server/pkg/require"
+)
+
+func TestIndex(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	Index(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, "Hello, World!", rec.Body.String())
+}

--- a/server/internal/routes/routes.go
+++ b/server/internal/routes/routes.go
@@ -1,0 +1,8 @@
+package routes
+
+import "net/http"
+
+// Register attaches all application routes to the provided ServeMux.
+func Register(mux *http.ServeMux) {
+	mux.HandleFunc("/", Index)
+}

--- a/server/pkg/require/require.go
+++ b/server/pkg/require/require.go
@@ -25,6 +25,26 @@ func Equalf[T comparable](t *testing.T, want, got T, format string, args ...any)
 	}
 }
 
+// NotEqual is a helper function to assert the two given values are not equal.
+// It will fail the test if the values are equal.
+func NotEqual[T comparable](t *testing.T, want, got T) {
+	t.Helper()
+
+	if want == got {
+		t.Fatalf("\nwant: NOT %v\n got: %v", want, got)
+	}
+}
+
+// NotEqualf is a helper function to assert the two given values are not equal.
+// It will fail the test if the values are equal.
+func NotEqualf[T comparable](t *testing.T, want, got T, format string, args ...any) {
+	t.Helper()
+
+	if want == got {
+		t.Fatalf(format, args...)
+	}
+}
+
 // EqualBytes is a helper function to assert the two given byte slices are equal.
 func EqualBytes(t *testing.T, want, got []byte) {
 	t.Helper()


### PR DESCRIPTION
Closes #55 

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR introduces a clear and consistent structure for defining and registering HTTP middleware and route handlers in the Go backend. It standardises how middleware and routes are organised under `internal/`, and centralises route registration so `main` is only responsible for wiring the HTTP server together using the standard library `net/http.ServeMux`.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Introduced a standard folder structure under `internal/` for middleware and routes
- Added a consistent middleware pattern using `http.Handler` composition
- Organised route handlers by endpoint or domain under `internal/routes/`
- Added a single route registration entrypoint to register all routes on a provided `*http.ServeMux`
- Improved testability of handlers and middleware by enforcing clear boundaries and signatures