### PR TITLE
chore(ci): add golangci-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,8 +37,8 @@ jobs:
       - name: Format
         run: pnpm format
 
-  lint:
-    name: Lint
+  eslint:
+    name: ESLint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -60,3 +60,20 @@ jobs:
 
       - name: Lint
         run: pnpm lint
+
+  golangci-lint:
+    name: Go Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.6

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -2,5 +2,8 @@
 export default {
   '*.{js,jsx,ts,tsx,md,html,css,json,yaml}': 'prettier --write',
   '*.{js,jsx,ts,tsx}': 'eslint --fix',
-  '*.go': 'golangci-lint run --fix',
+  '*.go': (files) => {
+    const dirs = new Set(files.map((file) => file.substring(0, file.lastIndexOf('/'))));
+    return Array.from(dirs).map((dir) => `golangci-lint run --fix ${dir}`);
+  },
 };

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -2,5 +2,5 @@
 export default {
   '*.{js,jsx,ts,tsx,md,html,css,json,yaml}': 'prettier --write',
   '*.{js,jsx,ts,tsx}': 'eslint --fix',
-  '*.go': ['golangci-lint fmt', 'golangci-lint run'],
+  '*.go': 'golangci-lint run --fix',
 };

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -2,8 +2,4 @@
 export default {
   '*.{js,jsx,ts,tsx,md,html,css,json,yaml}': 'prettier --write',
   '*.{js,jsx,ts,tsx}': 'eslint --fix',
-  '*.go': (files) => {
-    const dirs = new Set(files.map((file) => file.substring(0, file.lastIndexOf('/'))));
-    return Array.from(dirs).map((dir) => `golangci-lint run --fix ${dir}`);
-  },
 };

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -2,4 +2,5 @@
 export default {
   '*.{js,jsx,ts,tsx,md,html,css,json,yaml}': 'prettier --write',
   '*.{js,jsx,ts,tsx}': 'eslint --fix',
+  '*.go': ['golangci-lint fmt', 'golangci-lint run'],
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "format": "prettier --check \"**/*.{js,jsx,ts,tsx,md,html,css,json,yaml}\"",
     "lint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
+    "golint": "golangci-lint run",
     "prepare": "husky"
   },
   "dependencies": {

--- a/server/cmd/tw/main.go
+++ b/server/cmd/tw/main.go
@@ -102,7 +102,11 @@ func run(ctx context.Context, cfg *config.Config) error {
 
 		slog.Info("server shutting down")
 
-		defer server.Close()
+		defer func() {
+			if err := server.Close(); err != nil {
+				slog.Warn("failed to close server", "err", err)
+			}
+		}()
 
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer shutdownCancel()

--- a/server/cmd/tw/main.go
+++ b/server/cmd/tw/main.go
@@ -104,7 +104,7 @@ func run(ctx context.Context, cfg *config.Config) error {
 
 		defer func() {
 			if err := server.Close(); err != nil {
-				slog.Warn("failed to close server", "err", err)
+				slog.Error("failed to close server", "err", err)
 			}
 		}()
 

--- a/server/internal/routes/index.go
+++ b/server/internal/routes/index.go
@@ -11,6 +11,6 @@ func Index(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write([]byte("Hello, World!")); err != nil {
-		logger.Error("failed to write response", "err", err)
+		logger.Warn("failed to write response", "err", err)
 	}
 }

--- a/server/internal/routes/index.go
+++ b/server/internal/routes/index.go
@@ -1,8 +1,16 @@
 package routes
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/String-sg/teacher-workspace/server/internal/middleware"
+)
 
 func Index(w http.ResponseWriter, r *http.Request) {
+	logger := middleware.LoggerFromContext(r.Context())
+
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("Hello, World!"))
+	if _, err := w.Write([]byte("Hello, World!")); err != nil {
+		logger.Error("failed to write response", "err", err)
+	}
 }

--- a/server/pkg/dotenv/dotenv_test.go
+++ b/server/pkg/dotenv/dotenv_test.go
@@ -122,7 +122,10 @@ func TestDecode_LogLevel(t *testing.T) {
 			err := decode([]byte(content), &cfg)
 
 			t.Cleanup(func() {
-				os.Unsetenv("TEST_LOG_LEVEL")
+				err := os.Unsetenv("TEST_LOG_LEVEL")
+				if err != nil {
+					t.Fatalf("failed to unset env: %v", err)
+				}
 			})
 
 			if test.wantErr {
@@ -179,7 +182,10 @@ func TestDecode_Duration(t *testing.T) {
 			err := decode([]byte(content), &cfg)
 
 			t.Cleanup(func() {
-				os.Unsetenv("TEST_READ_TIMEOUT")
+				err := os.Unsetenv("TEST_READ_TIMEOUT")
+				if err != nil {
+					t.Fatalf("failed to unset env: %v", err)
+				}
 			})
 
 			if test.wantErr {

--- a/server/pkg/dotenv/dotenv_test.go
+++ b/server/pkg/dotenv/dotenv_test.go
@@ -122,8 +122,7 @@ func TestDecode_LogLevel(t *testing.T) {
 			err := decode([]byte(content), &cfg)
 
 			t.Cleanup(func() {
-				err := os.Unsetenv("TEST_LOG_LEVEL")
-				if err != nil {
+				if err := os.Unsetenv("TEST_LOG_LEVEL"); err != nil {
 					t.Fatalf("failed to unset env: %v", err)
 				}
 			})
@@ -182,8 +181,7 @@ func TestDecode_Duration(t *testing.T) {
 			err := decode([]byte(content), &cfg)
 
 			t.Cleanup(func() {
-				err := os.Unsetenv("TEST_READ_TIMEOUT")
-				if err != nil {
+				if err := os.Unsetenv("TEST_READ_TIMEOUT"); err != nil {
 					t.Fatalf("failed to unset env: %v", err)
 				}
 			})


### PR DESCRIPTION
closes #56 

## 🚀 Summary

Add default golangci-lint configuration for workspace and ci

## ✏️ Changes

- Add golangci-lint to github ci
- Fix existing Go lint errors
