### PR TITLE
refactor: convert existing tests to top-level + subtests style

### DIFF
--- a/server/internal/middleware/middleware_test.go
+++ b/server/internal/middleware/middleware_test.go
@@ -9,53 +9,55 @@ import (
 	"github.com/String-sg/teacher-workspace/server/pkg/require"
 )
 
-func TestChain_Order(t *testing.T) {
-	var calls []string
+func TestChain(t *testing.T) {
+	t.Run("applies middleware in order around the handler", func(t *testing.T) {
+		var calls []string
 
-	m1 := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			calls = append(calls, "m1-before")
-			next.ServeHTTP(w, r)
-			calls = append(calls, "m1-after")
-		})
-	}
-	m2 := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			calls = append(calls, "m2-before")
-			next.ServeHTTP(w, r)
-			calls = append(calls, "m2-after")
-		})
-	}
+		m1 := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls = append(calls, "m1-before")
+				next.ServeHTTP(w, r)
+				calls = append(calls, "m1-after")
+			})
+		}
+		m2 := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls = append(calls, "m2-before")
+				next.ServeHTTP(w, r)
+				calls = append(calls, "m2-after")
+			})
+		}
 
-	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls = append(calls, "handler")
-		w.WriteHeader(http.StatusOK)
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, "handler")
+			w.WriteHeader(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+
+		Chain(h, m1, m2).ServeHTTP(rec, req)
+
+		res := rec.Result()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.Equal(t, "m1-before,m2-before,handler,m2-after,m1-after", strings.Join(calls, ","))
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	rec := httptest.NewRecorder()
+	t.Run("calls handler directly when no middleware is given", func(t *testing.T) {
+		called := false
 
-	Chain(h, m1, m2).ServeHTTP(rec, req)
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		})
 
-	res := rec.Result()
-	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, "m1-before,m2-before,handler,m2-after,m1-after", strings.Join(calls, ","))
-}
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
 
-func TestChain_NoMiddleware(t *testing.T) {
-	called := false
+		Chain(h).ServeHTTP(rec, req)
 
-	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
-		w.WriteHeader(http.StatusOK)
+		res := rec.Result()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.True(t, called)
 	})
-
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	rec := httptest.NewRecorder()
-
-	Chain(h).ServeHTTP(rec, req)
-
-	res := rec.Result()
-	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.True(t, called)
 }


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR standardises test files to use the top-level + subtests style for consistency across the codebase. Subtests give each case its own name in `go test -v` output, making failures easier to identify, and allow individual cases to be run in isolation with `go test -run TestFoo/case_name`.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Consolidated separate top-level test functions into subtests using `t.Run`
