### PR TITLE
feat: add OTPaaS-backed OTP request/verify endpoints

### DIFF
--- a/server/cmd/tw/main.go
+++ b/server/cmd/tw/main.go
@@ -56,7 +56,7 @@ func main() {
 func run(ctx context.Context, cfg *config.Config) error {
 	mux := http.NewServeMux()
 
-	routes.Register(mux)
+	routes.Register(mux, cfg)
 
 	handler := middleware.Chain(mux, middleware.RequestID)
 

--- a/server/cmd/tw/main.go
+++ b/server/cmd/tw/main.go
@@ -56,7 +56,8 @@ func main() {
 func run(ctx context.Context, cfg *config.Config) error {
 	mux := http.NewServeMux()
 
-	routes.Register(mux, cfg)
+	client := &http.Client{Timeout: cfg.Client.Timeout}
+	routes.Register(mux, cfg, client)
 
 	handler := middleware.Chain(mux, middleware.RequestID)
 

--- a/server/cmd/tw/main.go
+++ b/server/cmd/tw/main.go
@@ -56,7 +56,7 @@ func main() {
 func run(ctx context.Context, cfg *config.Config) error {
 	mux := http.NewServeMux()
 
-	client := &http.Client{Timeout: cfg.Client.Timeout}
+	client := &http.Client{Timeout: cfg.OTPaas.ClientTimeout}
 	routes.Register(mux, cfg, client)
 
 	handler := middleware.Chain(mux, middleware.RequestID)

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -10,6 +10,8 @@ type Config struct {
 	LogLevel slog.Level `dotenv:"TW_LOG_LEVEL"`
 
 	Server ServerConfig `dotenv:",squash"`
+
+	OTPaas OTPaasConfig `dotenv:",squash"`
 }
 
 // ServerConfig represents the configuration for the HTTP server.
@@ -20,6 +22,13 @@ type ServerConfig struct {
 	ReadHeaderTimeout time.Duration `dotenv:"TW_SERVER_READ_HEADER_TIMEOUT"`
 	WriteTimeout      time.Duration `dotenv:"TW_SERVER_WRITE_TIMEOUT"`
 	IdleTimeout       time.Duration `dotenv:"TW_SERVER_IDLE_TIMEOUT"`
+}
+
+type OTPaasConfig struct {
+	ID        string `dotenv:"TW_APP_ID"`
+	Namespace string `dotenv:"TW_APP_NAMESPACE"`
+	Secret    string `dotenv:"TW_APP_SECRET"`
+	Host      string `dotenv:"TW_TECHPASS_OTP_HOST"`
 }
 
 // Default returns the default configuration for the application.
@@ -34,6 +43,13 @@ func Default() *Config {
 			ReadHeaderTimeout: 10 * time.Second,
 			WriteTimeout:      60 * time.Second,
 			IdleTimeout:       120 * time.Second,
+		},
+
+		OTPaas: OTPaasConfig{
+			ID:        "",
+			Namespace: "",
+			Secret:    "",
+			Host:      "https://otp.techpass.suite.gov.sg",
 		},
 	}
 }

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -12,6 +12,8 @@ type Config struct {
 	Server ServerConfig `dotenv:",squash"`
 
 	OTPaas OTPaasConfig `dotenv:",squash"`
+
+	Client ClientConfig `dotenv:",squash"`
 }
 
 // ServerConfig represents the configuration for the HTTP server.
@@ -22,6 +24,10 @@ type ServerConfig struct {
 	ReadHeaderTimeout time.Duration `dotenv:"TW_SERVER_READ_HEADER_TIMEOUT"`
 	WriteTimeout      time.Duration `dotenv:"TW_SERVER_WRITE_TIMEOUT"`
 	IdleTimeout       time.Duration `dotenv:"TW_SERVER_IDLE_TIMEOUT"`
+}
+
+type ClientConfig struct {
+	Timeout time.Duration `dotenv:"TW_CLIENT_TIMEOUT"`
 }
 
 type OTPaasConfig struct {
@@ -43,6 +49,10 @@ func Default() *Config {
 			ReadHeaderTimeout: 10 * time.Second,
 			WriteTimeout:      60 * time.Second,
 			IdleTimeout:       120 * time.Second,
+		},
+
+		Client: ClientConfig{
+			Timeout: 100 * time.Second,
 		},
 
 		OTPaas: OTPaasConfig{

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -5,15 +5,21 @@ import (
 	"time"
 )
 
+type Environment string
+
+const (
+	EnvironmentDevelopment Environment = "development"
+	EnvironmentStaging     Environment = "staging"
+	EnvironmentProduction  Environment = "production"
+)
+
 // Config is the main configuration for the application.
 type Config struct {
-	LogLevel slog.Level `dotenv:"TW_LOG_LEVEL"`
+	LogLevel    slog.Level  `dotenv:"TW_LOG_LEVEL"`
+	Environment Environment `dotenv:"TW_ENV"`
 
 	Server ServerConfig `dotenv:",squash"`
-
 	OTPaas OTPaasConfig `dotenv:",squash"`
-
-	Client ClientConfig `dotenv:",squash"`
 }
 
 // ServerConfig represents the configuration for the HTTP server.
@@ -26,21 +32,19 @@ type ServerConfig struct {
 	IdleTimeout       time.Duration `dotenv:"TW_SERVER_IDLE_TIMEOUT"`
 }
 
-type ClientConfig struct {
-	Timeout time.Duration `dotenv:"TW_CLIENT_TIMEOUT"`
-}
-
 type OTPaasConfig struct {
-	ID        string `dotenv:"TW_APP_ID"`
-	Namespace string `dotenv:"TW_APP_NAMESPACE"`
-	Secret    string `dotenv:"TW_APP_SECRET"`
-	Host      string `dotenv:"TW_TECHPASS_OTP_HOST"`
+	ID            string        `dotenv:"TW_OTPAAS_APP_ID"`
+	Namespace     string        `dotenv:"TW_OTPAAS_APP_NAMESPACE"`
+	Secret        string        `dotenv:"TW_OTPAAS_APP_SECRET"`
+	Host          string        `dotenv:"TW_OTPAAS_OTP_HOST"`
+	ClientTimeout time.Duration `dotenv:"TW_OTPAAS_CLIENT_TIMEOUT"`
 }
 
 // Default returns the default configuration for the application.
 func Default() *Config {
 	return &Config{
-		LogLevel: slog.LevelInfo,
+		LogLevel:    slog.LevelInfo,
+		Environment: EnvironmentDevelopment,
 
 		Server: ServerConfig{
 			Port: 8080,
@@ -51,15 +55,12 @@ func Default() *Config {
 			IdleTimeout:       120 * time.Second,
 		},
 
-		Client: ClientConfig{
-			Timeout: 100 * time.Second,
-		},
-
 		OTPaas: OTPaasConfig{
-			ID:        "",
-			Namespace: "",
-			Secret:    "",
-			Host:      "https://otp.techpass.suite.gov.sg",
+			ID:            "",
+			Namespace:     "",
+			Secret:        "",
+			Host:          "https://otp.techpass.suite.gov.sg",
+			ClientTimeout: 100 * time.Second,
 		},
 	}
 }

--- a/server/internal/routes/index.go
+++ b/server/internal/routes/index.go
@@ -6,7 +6,7 @@ import (
 	"github.com/String-sg/teacher-workspace/server/internal/middleware"
 )
 
-func Index(w http.ResponseWriter, r *http.Request) {
+func (handler *Handler) Index(w http.ResponseWriter, r *http.Request) {
 	logger := middleware.LoggerFromContext(r.Context())
 
 	w.WriteHeader(http.StatusOK)

--- a/server/internal/routes/index_test.go
+++ b/server/internal/routes/index_test.go
@@ -5,14 +5,16 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/String-sg/teacher-workspace/server/internal/config"
 	"github.com/String-sg/teacher-workspace/server/pkg/require"
 )
 
 func TestIndex(t *testing.T) {
+	h := &Handler{cfg: config.Default()}
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 
-	Index(rec, req)
+	h.Index(rec, req)
 
 	res := rec.Result()
 	require.Equal(t, http.StatusOK, res.StatusCode)

--- a/server/internal/routes/index_test.go
+++ b/server/internal/routes/index_test.go
@@ -5,12 +5,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/String-sg/teacher-workspace/server/internal/config"
 	"github.com/String-sg/teacher-workspace/server/pkg/require"
 )
 
 func TestIndex(t *testing.T) {
-	h := &Handler{cfg: config.Default()}
+	h := &Handler{}
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 

--- a/server/internal/routes/otp.go
+++ b/server/internal/routes/otp.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 )
 
@@ -16,19 +17,28 @@ func RequestOTP(w http.ResponseWriter, r *http.Request) {
 	}
 	http.SetCookie(w, &cookie)
 
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("RequestOTP"))
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		fmt.Println("There is an error")
+	} else {
+		fmt.Println("No error")
+	}
 
+	bodyString := string(bodyBytes)
+	fmt.Println("Body String:", bodyString)
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(bodyBytes)
 }
 
 func VerifyOTP(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("VerifyOTP"))
-
 	cookie, err := r.Cookie("session_id")
 	if err != nil {
 		fmt.Println("There is an error")
 	} else {
 		fmt.Println(cookie.Value)
 	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(cookie.Value))
 }

--- a/server/internal/routes/otp.go
+++ b/server/internal/routes/otp.go
@@ -1,13 +1,34 @@
 package routes
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 func RequestOTP(w http.ResponseWriter, r *http.Request) {
+	cookie := http.Cookie{
+		Name:     "session_id",
+		Value:    "123456",
+		Path:     "/",
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
+	http.SetCookie(w, &cookie)
+
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("RequestOTP"))
+
 }
 
 func VerifyOTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("VerifyOTP"))
+
+	cookie, err := r.Cookie("session_id")
+	if err != nil {
+		fmt.Println("There is an error")
+	} else {
+		fmt.Println(cookie.Value)
+	}
 }

--- a/server/internal/routes/otp.go
+++ b/server/internal/routes/otp.go
@@ -184,7 +184,7 @@ func (h *Handler) RequestOTP(w http.ResponseWriter, r *http.Request) {
 		Name:     "session_id",
 		Value:    sessionID,
 		Path:     "/",
-		Secure:   false,
+		Secure:   true,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 	}

--- a/server/internal/routes/otp.go
+++ b/server/internal/routes/otp.go
@@ -1,0 +1,13 @@
+package routes
+
+import "net/http"
+
+func RequestOTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("RequestOTP"))
+}
+
+func VerifyOTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("VerifyOTP"))
+}

--- a/server/internal/routes/otp.go
+++ b/server/internal/routes/otp.go
@@ -123,8 +123,7 @@ func (h *Handler) RequestOTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if resp.StatusCode == http.StatusOK {
-		w.WriteHeader(http.StatusOK)
-		w.Write(body)
+		w.WriteHeader(http.StatusNoContent)
 	} else {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("Failed to request OTP."))
@@ -203,8 +202,7 @@ func (h *Handler) VerifyOTP(w http.ResponseWriter, r *http.Request) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("PIN verified"))
+		w.WriteHeader(http.StatusNoContent)
 	case http.StatusUnauthorized:
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte("Invalid PIN."))

--- a/server/internal/routes/otp.go
+++ b/server/internal/routes/otp.go
@@ -1,21 +1,49 @@
 package routes
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
 )
 
+var store = make(map[string]map[string]string)
+
 func RequestOTP(w http.ResponseWriter, r *http.Request) {
-	cookie := http.Cookie{
-		Name:     "session_id",
-		Value:    "123456",
-		Path:     "/",
-		Secure:   true,
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
+	c, err := r.Cookie("session_id")
+	store["session_id"] = map[string]string{"otp_flow_id": "123"}
+	fmt.Println(store["session_id"])
+
+	if err != nil {
+		id := make([]byte, 32)
+		if _, err := rand.Read(id); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		sessionID := base64.RawURLEncoding.EncodeToString(id)
+
+		cookie := http.Cookie{
+			Name:     "session_id",
+			Value:    sessionID,
+			Path:     "/",
+			Secure:   true,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+		}
+		http.SetCookie(w, &cookie)
+	} else {
+		cookie := http.Cookie{
+			Name:     "session_id",
+			Value:    c.Value,
+			Path:     "/",
+			Secure:   true,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+		}
+		http.SetCookie(w, &cookie)
 	}
-	http.SetCookie(w, &cookie)
 
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {

--- a/server/internal/routes/otp.go
+++ b/server/internal/routes/otp.go
@@ -1,17 +1,98 @@
 package routes
 
 import (
+	"bytes"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
-	"fmt"
+	"encoding/hex"
+	"encoding/json"
 	"io"
 	"net/http"
+	"os"
+	"strings"
 )
+
+var otpURL = os.Getenv("TECHPASS_OTP_HOST") + "/otp"
 
 var store = make(map[string]map[string]string)
 
+type RequestOTPInput struct {
+	Email string `json:"email"`
+}
+
+type OTPResponse struct {
+	ID string `json:"id"`
+}
+
+func buildAuthToken() string {
+	appSecret := os.Getenv("APP_SECRET")
+	appId := os.Getenv("APP_ID")
+	appNamespace := os.Getenv("APP_NAMESPACE")
+
+	h := hmac.New(sha256.New, []byte(appSecret))
+	h.Write([]byte(appId))
+
+	secret := hex.EncodeToString(h.Sum(nil))
+	combined := appNamespace + ":" + appId + ":" + secret
+
+	return base64.StdEncoding.EncodeToString([]byte(combined))
+}
+
 func RequestOTP(w http.ResponseWriter, r *http.Request) {
 	var sessionID string
+
+	var input RequestOTPInput
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Missing email in request body."))
+		return
+	}
+
+	if !strings.HasSuffix(input.Email, ".gov.sg") {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Invalid email"))
+		return
+	}
+
+	payload, err := json.Marshal(input)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	req, err := http.NewRequest("POST", otpURL, bytes.NewReader(payload))
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+buildAuthToken())
+	req.Header.Set("X-App-Id", os.Getenv("APP_ID"))
+	req.Header.Set("X-App-Namespace", os.Getenv("APP_NAMESPACE"))
+
+	resp, err := http.DefaultClient.Do(req)
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	var otpResp OTPResponse
+	if err := json.Unmarshal(body, &otpResp); err != nil {
+		w.WriteHeader(http.StatusBadGateway)
+		return
+	}
 
 	c, err := r.Cookie("session_id")
 	if err != nil {
@@ -20,13 +101,12 @@ func RequestOTP(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-
 		sessionID = base64.RawURLEncoding.EncodeToString(id)
 	} else {
 		sessionID = c.Value
 	}
 
-	store[sessionID] = map[string]string{"otp_flow_id": "123"}
+	store[sessionID] = map[string]string{"otp_flow_id": otpResp.ID}
 
 	cookie := http.Cookie{
 		Name:     "session_id",
@@ -38,15 +118,15 @@ func RequestOTP(w http.ResponseWriter, r *http.Request) {
 	}
 	http.SetCookie(w, &cookie)
 
-	bodyBytes, err := io.ReadAll(r.Body)
-	if err != nil {
-		fmt.Println("There is an error")
-	} else {
-		fmt.Println("No error")
-	}
+	w.Header().Set("Content-Type", "application/json")
 
-	w.WriteHeader(http.StatusOK)
-	w.Write(bodyBytes)
+	if resp.StatusCode == http.StatusOK {
+		w.WriteHeader(http.StatusOK)
+		w.Write(body)
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Failed to request OTP."))
+	}
 }
 
 func VerifyOTP(w http.ResponseWriter, r *http.Request) {
@@ -57,7 +137,6 @@ func VerifyOTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	session, ok := store[c.Value]
-
 	if !ok || session == nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		return

--- a/server/internal/routes/otp.go
+++ b/server/internal/routes/otp.go
@@ -77,6 +77,12 @@ func (h *Handler) RequestOTP(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.client.Do(req)
 
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Client timeout"))
+		return
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("Failed to request OTP."))
@@ -187,6 +193,12 @@ func (h *Handler) VerifyOTP(w http.ResponseWriter, r *http.Request) {
 	req.Header.Set("X-App-Namespace", h.cfg.OTPaas.Namespace)
 
 	resp, err := h.client.Do(req)
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Client timeout"))
+		return
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		switch resp.StatusCode {

--- a/server/internal/routes/otp.go
+++ b/server/internal/routes/otp.go
@@ -2,51 +2,32 @@ package routes
 
 import (
 	"bytes"
+	"context"
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 	"strings"
 
+	"github.com/String-sg/teacher-workspace/server/internal/config"
 	"github.com/String-sg/teacher-workspace/server/internal/middleware"
 )
 
 var store = make(map[string]map[string]string)
 
-type RequestOTPInput struct {
-	Email string `json:"email"`
-}
-
-type OTPResponse struct {
-	ID string `json:"id"`
-}
-
-type VerifyOTPInput struct {
-	PIN string `json:"pin"`
-}
-
-type VerifyOTPResponse struct {
-	ID string `json:"id"`
-}
-
-type ErrorResponse struct {
+type errorResponse struct {
 	Code    string      `json:"code"`
 	Message string      `json:"message"`
-	Errors  []ErrorBody `json:"error,omitempty"`
+	Errors  []errorBody `json:"error,omitempty"`
 }
 
-type ErrorResponseNoErrors struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-}
-
-type ErrorBody struct {
+type errorBody struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
 }
@@ -55,71 +36,90 @@ const (
 	ErrorCodeInvalidForm         = "INVALID_FORM"
 	ErrorCodeInvalidAuth         = "AUTHORIZATION_FAILED"
 	ErrorCodeInternalServerError = "INTERNAL_SERVER_ERROR"
+	ErrorCodeRequestTimeout      = "REQUEST_TIMEOUT"
 )
 
-func writeErrorResponse(w http.ResponseWriter, logger *slog.Logger, code string, message string, errors ...ErrorBody) {
-	if len(errors) == 0 {
-		if err := json.NewEncoder(w).Encode(ErrorResponseNoErrors{
-			Code:    code,
-			Message: message,
-		}); err != nil {
-			logger.Error("Failed to encode error response", "error", err)
-		}
-		return
+// isAllowedEmail returns true if the email domain is allowed for the given environment.
+// Production: only @schools.gov.sg. Staging/development: @schools.gov.sg or @tech.gov.sg.
+func isAllowedEmail(email string, env config.Environment) bool {
+	if env == config.EnvironmentProduction {
+		return strings.HasSuffix(email, "@schools.gov.sg")
 	}
+	return strings.HasSuffix(email, "@schools.gov.sg") || strings.HasSuffix(email, "@tech.gov.sg")
+}
 
-	if err := json.NewEncoder(w).Encode(ErrorResponse{
+// writeClientErrorResponse writes a JSON error response for 4xx client errors
+func writeClientErrorResponse(w http.ResponseWriter, logger *slog.Logger, statusCode int, code string, message string, errors ...errorBody) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	if err := json.NewEncoder(w).Encode(errorResponse{
 		Code:    code,
 		Message: message,
 		Errors:  errors,
 	}); err != nil {
-		logger.Error("Failed to encode error response", "error", err)
+		logger.Error("Failed to encode error response", "err", err)
 	}
 }
 
-func buildAuthToken(appSecret string, appId string, appNamespace string) string {
-	h := hmac.New(sha256.New, []byte(appSecret))
-	h.Write([]byte(appId))
+// writeServerErrorResponse writes a plain text error response for 5xx server errors using http.Error
+func writeServerErrorResponse(w http.ResponseWriter, statusCode int, message string) {
+	http.Error(w, message, statusCode)
+}
 
-	secret := hex.EncodeToString(h.Sum(nil))
-	combined := appNamespace + ":" + appId + ":" + secret
+func buildAuthToken(appId, appNamespace, appSecret string) string {
+	mac := hmac.New(sha256.New, []byte(appSecret))
+	mac.Write([]byte(appId))
 
-	return base64.StdEncoding.EncodeToString([]byte(combined))
+	sig := hex.EncodeToString(mac.Sum(nil))
+	payload := appNamespace + ":" + appId + ":" + sig
+
+	return base64.StdEncoding.EncodeToString([]byte(payload))
+}
+
+type requestOTPRequest struct {
+	Email string `json:"email"`
+}
+
+type requestOTPResponse struct {
+	ID string `json:"id"`
+}
+
+type requestOTPOTPaasRequest struct {
+	Email string `json:"email"`
+}
+
+type requestOTPPaasResponse struct {
+	ID string `json:"id"`
 }
 
 func (h *Handler) RequestOTP(w http.ResponseWriter, r *http.Request) {
-	log := middleware.LoggerFromContext(r.Context())
-	var otpURL = h.cfg.OTPaas.Host + "/otp"
-	var sessionID string
+	logger := middleware.LoggerFromContext(r.Context())
 
-	var input RequestOTPInput
+	var input requestOTPRequest
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		writeErrorResponse(w, log, ErrorCodeInvalidForm, "One or more input has an error")
-		log.Error(fmt.Sprintf("[%d]: Email not found in request body", http.StatusBadRequest), "error", err)
+		writeClientErrorResponse(w, logger, http.StatusBadRequest, ErrorCodeInvalidForm, "One or more input has an error")
+		logger.Error("Email not found in request body", "err", err)
 		return
 	}
 
-	if !strings.HasSuffix(input.Email, ".gov.sg") {
-		w.WriteHeader(http.StatusBadRequest)
-		writeErrorResponse(w, log, ErrorCodeInvalidForm, "One or more input has an error")
-		log.Error(fmt.Sprintf("[%d]: Email is not a valid schools.gov.sg email", http.StatusBadRequest), "error", nil)
+	if !isAllowedEmail(input.Email, h.cfg.Environment) {
+		writeClientErrorResponse(w, logger, http.StatusUnprocessableEntity, ErrorCodeInvalidForm, "One or more input has an error")
+		logger.Error("Email is not a valid schools.gov.sg email")
 		return
 	}
 
-	payload, err := json.Marshal(input)
+	otpaasPayload := requestOTPOTPaasRequest(input)
+	payload, err := json.Marshal(otpaasPayload)
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		writeErrorResponse(w, log, ErrorCodeInternalServerError, "Internal server error")
-		log.Error(fmt.Sprintf("[%d]: Failed to marshal request body", http.StatusInternalServerError), "error", err)
+		writeServerErrorResponse(w, http.StatusInternalServerError, "Internal server error")
+		logger.Error("Failed to marshal request body", "err", err)
 		return
 	}
 
-	req, err := http.NewRequest("POST", otpURL, bytes.NewReader(payload))
+	req, err := http.NewRequest("POST", h.cfg.OTPaas.Host+"/otp", bytes.NewReader(payload))
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		writeErrorResponse(w, log, ErrorCodeInternalServerError, "Internal server error")
-		log.Error(fmt.Sprintf("[%d]: Failed to create request", http.StatusInternalServerError), "error", err)
+		writeServerErrorResponse(w, http.StatusInternalServerError, "Internal server error")
+		logger.Error("Failed to create request", "err", err)
 		return
 	}
 
@@ -129,63 +129,64 @@ func (h *Handler) RequestOTP(w http.ResponseWriter, r *http.Request) {
 	req.Header.Set("X-App-Namespace", h.cfg.OTPaas.Namespace)
 
 	resp, err := h.client.Do(req)
-
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		writeErrorResponse(w, log, ErrorCodeInternalServerError, "Internal server error")
-		log.Error(fmt.Sprintf("[%d]: Request timeout", http.StatusInternalServerError), "error", err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			writeServerErrorResponse(w, http.StatusGatewayTimeout, "Request timeout. Please try again later.")
+			logger.Error("OTPaas request timeout", "err", err)
+			return
+		}
+
+		writeServerErrorResponse(w, http.StatusInternalServerError, "Internal server error")
+		logger.Error("Error sending request to OTPaas", "err", err)
 		return
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		w.WriteHeader(http.StatusInternalServerError)
 		// TODO: update the error message from figma when available
-		writeErrorResponse(w, log, ErrorCodeInvalidAuth, "Something went wrong. Please try again later.")
-		log.Error(fmt.Sprintf("[%d]: Authorization failed", resp.StatusCode), "error", err)
+		writeServerErrorResponse(w, http.StatusInternalServerError, "Something went wrong. Please try again later.")
+		logger.Error("Authorization failed", "err", err, "otpaas_status_code", resp.StatusCode)
 		return
 	}
 
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Error("Failed to close response body", "error", err)
+			logger.Error("Failed to close response body", "err", err)
 		}
 	}()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		writeErrorResponse(w, log, ErrorCodeInternalServerError, "Internal server error")
-		log.Error(fmt.Sprintf("[%d]: Failed to read response body", resp.StatusCode), "error", err)
+		writeServerErrorResponse(w, http.StatusInternalServerError, "Internal server error")
+		logger.Error("Failed to read response body", "err", err, "otpaas_status_code", resp.StatusCode)
 		return
 	}
 
-	var otpResp OTPResponse
+	var otpResp requestOTPPaasResponse
 	if err := json.Unmarshal(body, &otpResp); err != nil {
-		w.WriteHeader(http.StatusBadGateway)
-		writeErrorResponse(w, log, ErrorCodeInternalServerError, "Internal server error")
-		log.Error(fmt.Sprintf("[%d]: Failed to unmarshal response body", resp.StatusCode), "error", err)
+		writeServerErrorResponse(w, http.StatusInternalServerError, "Internal server error")
+		logger.Error("Failed to unmarshal response body", "err", err, "otpaas_status_code", resp.StatusCode)
 		return
 	}
+
+	if otpResp.ID == "" {
+		writeServerErrorResponse(w, http.StatusInternalServerError, "Internal server error")
+		logger.Error("Failed to get `otp_flow_id` from OTPaas", "err", err, "otpaas_status_code", resp.StatusCode)
+		return
+	}
+
+	var sessionID string
 
 	c, err := r.Cookie("session_id")
 	if err != nil {
 		id := make([]byte, 32)
 		if _, err := rand.Read(id); err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			writeErrorResponse(w, log, ErrorCodeInternalServerError, "Internal server error")
-			log.Error(fmt.Sprintf("[%d]: Failed to generate session ID", resp.StatusCode), "error", err)
+			writeServerErrorResponse(w, http.StatusInternalServerError, "Internal server error")
+			logger.Error("Failed to generate session ID", "err", err, "otpaas_status_code", resp.StatusCode)
 			return
 		}
 		sessionID = base64.RawURLEncoding.EncodeToString(id)
 	} else {
 		sessionID = c.Value
-	}
-
-	if otpResp.ID == "" {
-		w.WriteHeader(http.StatusInternalServerError)
-		writeErrorResponse(w, log, ErrorCodeInternalServerError, "Internal server error")
-		log.Error(fmt.Sprintf("[%d]: Failed to get `otp_flow_id` from OTPaas", resp.StatusCode), "error", err)
-		return
 	}
 
 	store[sessionID] = map[string]string{"otp_flow_id": otpResp.ID}
@@ -194,68 +195,74 @@ func (h *Handler) RequestOTP(w http.ResponseWriter, r *http.Request) {
 		Name:     "session_id",
 		Value:    sessionID,
 		Path:     "/",
-		Secure:   true,
+		Secure:   h.cfg.Environment == config.EnvironmentProduction || h.cfg.Environment == config.EnvironmentStaging,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 	}
 	http.SetCookie(w, &cookie)
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusNoContent)
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(requestOTPResponse(otpResp)); err != nil {
+		logger.Error("Failed to encode error response", "err", err)
+	}
 
 }
 
+type verifyOTPRequest struct {
+	PIN string `json:"pin"`
+}
+
+type verifyOTPOTPaasRequest struct {
+	PIN string `json:"pin"`
+}
+
 func (h *Handler) VerifyOTP(w http.ResponseWriter, r *http.Request) {
-	log := middleware.LoggerFromContext(r.Context())
-	var otpURL = h.cfg.OTPaas.Host + "/otp"
+	logger := middleware.LoggerFromContext(r.Context())
 
-	c, err := r.Cookie("session_id")
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		writeErrorResponse(w, log, ErrorCodeInternalServerError, "Internal server error")
-		log.Error(fmt.Sprintf("[%d]: Missing session_id in cookie", http.StatusInternalServerError), "error", err)
-		return
-	}
-
-	var input VerifyOTPInput
+	var input verifyOTPRequest
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		writeErrorResponse(w, log, ErrorCodeInvalidForm, "One or more input has an error")
-		log.Error(fmt.Sprintf("[%d]: Pin not found in request body", http.StatusBadRequest), "error", err)
+		writeClientErrorResponse(w, logger, http.StatusBadRequest, ErrorCodeInvalidForm, "One or more input has an error")
+		logger.Error("Pin not found in request body", "err", err)
 		return
 	}
 
 	if len(input.PIN) != 6 {
-		w.WriteHeader(http.StatusBadRequest)
-		writeErrorResponse(w, log, ErrorCodeInvalidForm, "One or more input has an error")
-		log.Error(fmt.Sprintf("[%d]: Pin is not a valid 6 digit PIN", http.StatusBadRequest), "error", err)
+		writeClientErrorResponse(w, logger, http.StatusUnprocessableEntity, ErrorCodeInvalidForm, "One or more input has an error")
+		logger.Error("Pin is not a valid 6 digit PIN")
+		return
+	}
+
+	c, err := r.Cookie("session_id")
+	if err != nil {
+		writeServerErrorResponse(w, http.StatusInternalServerError, "Internal server error")
+		logger.Error("Missing session_id in cookie", "err", err)
 		return
 	}
 
 	session, ok := store[c.Value]
-	if !ok || session == nil {
-		w.WriteHeader(http.StatusUnauthorized)
+	if !ok {
 		// TODO: update the error message from figma when available
-		writeErrorResponse(w, log, ErrorCodeInvalidAuth, "Failed to authenticate session.")
-		log.Error(fmt.Sprintf("[%d]: Session not found in store", http.StatusUnauthorized), "error", err)
+		writeClientErrorResponse(w, logger, http.StatusUnauthorized, ErrorCodeInvalidAuth, "Failed to authenticate session.")
+		logger.Error("Session not found in store", "err", err)
+		return
+	}
+
+	otpaasPayload := verifyOTPOTPaasRequest(input)
+	payload, err := json.Marshal(otpaasPayload)
+	if err != nil {
+		writeServerErrorResponse(w, http.StatusInternalServerError, "Internal server error")
+		logger.Error("Failed to marshal request body", "err", err)
 		return
 	}
 
 	otpFlowID := session["otp_flow_id"]
 
-	payload, err := json.Marshal(input)
+	req, err := http.NewRequest("PUT", h.cfg.OTPaas.Host+"/otp/"+otpFlowID, bytes.NewReader(payload))
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		writeErrorResponse(w, log, ErrorCodeInternalServerError, "Internal server error")
-		log.Error(fmt.Sprintf("[%d]: Failed to marshal request body", http.StatusInternalServerError), "error", err)
-		return
-	}
-
-	req, err := http.NewRequest("PUT", otpURL+"/"+otpFlowID, bytes.NewReader(payload))
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		writeErrorResponse(w, log, ErrorCodeInternalServerError, "Internal server error")
-		log.Error(fmt.Sprintf("[%d]: Failed to create request", http.StatusInternalServerError), "error", err)
+		writeServerErrorResponse(w, http.StatusInternalServerError, "Internal server error")
+		logger.Error("Failed to create request", "err", err)
 		return
 	}
 
@@ -265,58 +272,38 @@ func (h *Handler) VerifyOTP(w http.ResponseWriter, r *http.Request) {
 	req.Header.Set("X-App-Namespace", h.cfg.OTPaas.Namespace)
 
 	resp, err := h.client.Do(req)
-
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		writeErrorResponse(w, log, ErrorCodeInternalServerError, "Internal server error")
-		log.Error(fmt.Sprintf("[%d]: Client timeout", http.StatusInternalServerError), "error", err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			writeServerErrorResponse(w, http.StatusGatewayTimeout, "Request timeout. Please try again later.")
+			logger.Error("OTPaas request timeout", "err", err)
+			return
+		}
+
+		writeServerErrorResponse(w, http.StatusInternalServerError, "Internal server error")
+		logger.Error("Error sending request to OTPaas", "err", err)
 		return
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		switch resp.StatusCode {
 		case http.StatusUnauthorized:
-			w.WriteHeader(http.StatusUnauthorized)
-			writeErrorResponse(w, log, ErrorCodeInvalidAuth, "Failed to authenticate session.")
-			log.Error(fmt.Sprintf("[%d]: Invalid PIN", resp.StatusCode), "error", err)
+			writeClientErrorResponse(w, logger, http.StatusUnprocessableEntity, ErrorCodeInvalidAuth, "Failed to authenticate session.")
+			logger.Error("Invalid PIN", "err", err, "otpaas_status_code", resp.StatusCode)
 		case http.StatusNotFound:
-			w.WriteHeader(http.StatusUnauthorized)
-			writeErrorResponse(w, log, ErrorCodeInvalidAuth, "Failed to authenticate session.")
-			log.Error(fmt.Sprintf("[%d]: Pin expired", resp.StatusCode), "error", err)
-		case http.StatusGone:
-			w.WriteHeader(http.StatusUnauthorized)
-			writeErrorResponse(w, log, ErrorCodeInvalidAuth, "Failed to authenticate session.")
-			log.Error(fmt.Sprintf("[%d]", resp.StatusCode), "error", err)
-			return
+			writeClientErrorResponse(w, logger, http.StatusUnprocessableEntity, ErrorCodeInvalidAuth, "Failed to authenticate session.")
+			logger.Error("Pin expired", "err", err, "otpaas_status_code", resp.StatusCode)
 		default:
-			w.WriteHeader(http.StatusInternalServerError)
-			writeErrorResponse(w, log, ErrorCodeInternalServerError, "Internal server error")
-			log.Error(fmt.Sprintf("[%d] Internal server error", resp.StatusCode), "error", err)
+			writeServerErrorResponse(w, http.StatusInternalServerError, "Internal server error")
+			logger.Error("Internal server error", "err", err, "otpaas_status_code", resp.StatusCode)
 			return
 		}
 	}
 
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Error("Failed to close response body", "error", err)
+			logger.Error("Failed to close response body", "err", err)
 		}
 	}()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		writeErrorResponse(w, log, ErrorCodeInternalServerError, "Internal server error")
-		log.Error(fmt.Sprintf("[%d]: Failed to read response body", resp.StatusCode), "error", err)
-		return
-	}
-
-	var verifyOTPResponse VerifyOTPResponse
-	if err := json.Unmarshal(body, &verifyOTPResponse); err != nil {
-		w.WriteHeader(http.StatusBadGateway)
-		writeErrorResponse(w, log, ErrorCodeInternalServerError, "Internal server error")
-		log.Error(fmt.Sprintf("[%d]: Failed to unmarshal response body", resp.StatusCode), "error", err)
-		return
-	}
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/server/internal/routes/otp_test.go
+++ b/server/internal/routes/otp_test.go
@@ -1,9 +1,11 @@
 package routes
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/String-sg/teacher-workspace/server/internal/config"
@@ -14,18 +16,32 @@ func resetStore() {
 	store = make(map[string]map[string]string)
 }
 
-func TestRequestOTP_WithCookie(t *testing.T) {
-	h := &Handler{cfg: config.Default()}
+type RoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+func TestRequestOTP_WithCookieOTPFlowID(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(`{"id": "123"}`)))}, nil
+	})
+
+	h := &Handler{cfg: config.Default(), client: &http.Client{Transport: rt}}
 	resetStore()
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", strings.NewReader("yes"))
+	payload := map[string]string{"email": "test@gov.sg"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", bytes.NewReader(b))
+
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
 
 	h.RequestOTP(rec, req)
 
 	res := rec.Result()
-	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	require.Equal(t, http.StatusNoContent, res.StatusCode)
 
 	// Should set/refresh the same cookie value.
 	var got *http.Cookie
@@ -43,40 +59,149 @@ func TestRequestOTP_WithCookie(t *testing.T) {
 	require.Equal(t, "123", session["otp_flow_id"])
 }
 
-func TestRequestOTP_NoCookie(t *testing.T) {
-	h := &Handler{cfg: config.Default()}
+func TestRequestOTP_WithoutOTPFlowID(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(`{}`)))}, nil
+	})
+
+	h := &Handler{cfg: config.Default(), client: &http.Client{Transport: rt}}
 	resetStore()
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", strings.NewReader("yes"))
+	payload := map[string]string{"email": "test@gov.sg"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", bytes.NewReader(b))
 	rec := httptest.NewRecorder()
 
 	h.RequestOTP(rec, req)
 
 	res := rec.Result()
-	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, "yes", rec.Body.String())
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.Equal(t, "Failed to request OTP.", rec.Body.String())
 
 	cookies := res.Cookies()
-	require.True(t, len(cookies) > 0)
+	require.True(t, len(cookies) == 0)
+}
 
-	var sessionCookie *http.Cookie
-	for _, c := range cookies {
-		if c.Name == "session_id" {
-			sessionCookie = c
-			break
-		}
-	}
-	require.True(t, sessionCookie != nil)
-	require.NotEqual(t, "", sessionCookie.Value)
+func TestRequestOTP_InvalidEmail(t *testing.T) {
+	h := &Handler{cfg: config.Default(), client: &http.Client{}}
+	resetStore()
 
-	session, ok := store[sessionCookie.Value]
-	require.True(t, ok)
-	require.Equal(t, "123", session["otp_flow_id"])
+	payload := map[string]string{"email": "test@example.com"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", bytes.NewReader(b))
+	rec := httptest.NewRecorder()
+
+	h.RequestOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Equal(t, "Invalid email", rec.Body.String())
+}
+
+func TestRequestOTP_MissingEmail(t *testing.T) {
+	h := &Handler{cfg: config.Default(), client: &http.Client{}}
+	resetStore()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", nil)
+	rec := httptest.NewRecorder()
+
+	h.RequestOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Equal(t, "Missing email in request body.", rec.Body.String())
+}
+
+func TestRequestOTP_NotAuthorized(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusUnauthorized, Body: io.NopCloser(bytes.NewReader([]byte(`{}`)))}, nil
+	})
+
+	h := &Handler{cfg: config.Default(), client: &http.Client{Transport: rt}}
+	resetStore()
+
+	payload := map[string]string{"email": "test@gov.sg"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", bytes.NewReader(b))
+	rec := httptest.NewRecorder()
+
+	h.RequestOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.Equal(t, "Failed to request OTP.", rec.Body.String())
+}
+
+func TestRequestOTP_InternalServerError(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(bytes.NewReader([]byte(`{}`)))}, nil
+	})
+
+	h := &Handler{cfg: config.Default(), client: &http.Client{Transport: rt}}
+	resetStore()
+
+	payload := map[string]string{"email": "test@gov.sg"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", bytes.NewReader(b))
+	rec := httptest.NewRecorder()
+
+	h.RequestOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.Equal(t, "Failed to request OTP.", rec.Body.String())
 }
 
 func TestVerifyOTP_KnownSession(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(`{"id": "123"}`)))}, nil
+	})
+
+	h := &Handler{cfg: config.Default(), client: &http.Client{Transport: rt}}
+	resetStore()
+	store["abc"] = map[string]string{"otp_flow_id": "123"}
+
+	payload := map[string]string{"pin": "123456"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
+	rec := httptest.NewRecorder()
+
+	h.VerifyOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusNoContent, res.StatusCode)
+}
+
+func TestVerifyOTP_InvalidPin(t *testing.T) {
 	h := &Handler{cfg: config.Default()}
 	resetStore()
+
+	store["abc"] = map[string]string{"otp_flow_id": "123"}
+
+	payload := map[string]string{"pin": "1234567"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
+	rec := httptest.NewRecorder()
+
+	h.VerifyOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Equal(t, "Invalid pin", rec.Body.String())
+}
+
+func TestVerifyOTP_MissingPin(t *testing.T) {
+	h := &Handler{cfg: config.Default()}
+	resetStore()
+
 	store["abc"] = map[string]string{"otp_flow_id": "123"}
 
 	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", nil)
@@ -86,8 +211,128 @@ func TestVerifyOTP_KnownSession(t *testing.T) {
 	h.VerifyOTP(rec, req)
 
 	res := rec.Result()
-	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.Equal(t, "123", rec.Body.String())
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Equal(t, "Missing pin in request body.", rec.Body.String())
+}
+
+func TestVerifyOTP_BadRequest(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusBadRequest, Body: io.NopCloser(bytes.NewReader([]byte(`{}`)))}, nil
+	})
+
+	h := &Handler{cfg: config.Default(), client: &http.Client{Transport: rt}}
+	resetStore()
+
+	store["abc"] = map[string]string{"otp_flow_id": "123"}
+
+	payload := map[string]string{"pin": "123456"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
+	rec := httptest.NewRecorder()
+
+	h.VerifyOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.Equal(t, "Failed to verify OTP.", rec.Body.String())
+}
+
+func TestVerifyOTP_Unauthorized(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusUnauthorized, Body: io.NopCloser(bytes.NewReader([]byte(`{}`)))}, nil
+	})
+
+	h := &Handler{cfg: config.Default(), client: &http.Client{Transport: rt}}
+	resetStore()
+
+	store["abc"] = map[string]string{"otp_flow_id": "123"}
+
+	payload := map[string]string{"pin": "123456"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
+	rec := httptest.NewRecorder()
+
+	h.VerifyOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	require.Equal(t, "Invalid PIN.", rec.Body.String())
+}
+
+func TestVerifyOTP_NotFound(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(bytes.NewReader([]byte(`{}`)))}, nil
+	})
+
+	h := &Handler{cfg: config.Default(), client: &http.Client{Transport: rt}}
+	resetStore()
+
+	store["abc"] = map[string]string{"otp_flow_id": "123"}
+
+	payload := map[string]string{"pin": "123456"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
+	rec := httptest.NewRecorder()
+
+	h.VerifyOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	require.Equal(t, "PIN expired.", rec.Body.String())
+}
+
+func TestVerifyOTP_InternalServerError(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(bytes.NewReader([]byte(`{}`)))}, nil
+	})
+
+	h := &Handler{cfg: config.Default(), client: &http.Client{Transport: rt}}
+	resetStore()
+
+	store["abc"] = map[string]string{"otp_flow_id": "123"}
+
+	payload := map[string]string{"pin": "123456"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
+	rec := httptest.NewRecorder()
+
+	h.VerifyOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.Equal(t, "Failed to verify OTP.", rec.Body.String())
+}
+
+func TestVerifyOTP_Gone(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusGone, Body: io.NopCloser(bytes.NewReader([]byte(`{}`)))}, nil
+	})
+
+	h := &Handler{cfg: config.Default(), client: &http.Client{Transport: rt}}
+	resetStore()
+
+	store["abc"] = map[string]string{"otp_flow_id": "123"}
+
+	payload := map[string]string{"pin": "123456"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
+	rec := httptest.NewRecorder()
+
+	h.VerifyOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.Equal(t, "Failed to verify OTP.", rec.Body.String())
 }
 
 func TestVerifyOTP_MissingCookie(t *testing.T) {
@@ -100,14 +345,22 @@ func TestVerifyOTP_MissingCookie(t *testing.T) {
 	h.VerifyOTP(rec, req)
 
 	res := rec.Result()
-	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.Equal(t, "Missing session_id in cookie.", rec.Body.String())
 }
 
-func TestVerifyOTP_UnknownSession(t *testing.T) {
-	h := &Handler{cfg: config.Default()}
+func TestVerifyOTP_MissingSession(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(`{}`)))}, nil
+	})
+
+	h := &Handler{cfg: config.Default(), client: &http.Client{Transport: rt}}
 	resetStore()
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", nil)
+	payload := map[string]string{"pin": "123456"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
 
@@ -115,4 +368,5 @@ func TestVerifyOTP_UnknownSession(t *testing.T) {
 
 	res := rec.Result()
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	require.Equal(t, "Missing session in store.", rec.Body.String())
 }

--- a/server/internal/routes/otp_test.go
+++ b/server/internal/routes/otp_test.go
@@ -1,0 +1,112 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/String-sg/teacher-workspace/server/pkg/require"
+)
+
+func resetStore() {
+	store = make(map[string]map[string]string)
+}
+
+func TestRequestOTP_WithCookie(t *testing.T) {
+	resetStore()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", strings.NewReader("yes"))
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
+	rec := httptest.NewRecorder()
+
+	RequestOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	// Should set/refresh the same cookie value.
+	var got *http.Cookie
+	for _, c := range res.Cookies() {
+		if c.Name == "session_id" {
+			got = c
+			break
+		}
+	}
+	require.True(t, got != nil)
+	require.Equal(t, "abc", got.Value)
+
+	session, ok := store["abc"]
+	require.True(t, ok)
+	require.Equal(t, "123", session["otp_flow_id"])
+}
+
+func TestRequestOTP_NoCookie(t *testing.T) {
+	resetStore()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", strings.NewReader("yes"))
+	rec := httptest.NewRecorder()
+
+	RequestOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, "yes", rec.Body.String())
+
+	cookies := res.Cookies()
+	require.True(t, len(cookies) > 0)
+
+	var sessionCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == "session_id" {
+			sessionCookie = c
+			break
+		}
+	}
+	require.True(t, sessionCookie != nil)
+	require.NotEqual(t, "", sessionCookie.Value)
+
+	session, ok := store[sessionCookie.Value]
+	require.True(t, ok)
+	require.Equal(t, "123", session["otp_flow_id"])
+}
+
+func TestVerifyOTP_KnownSession(t *testing.T) {
+	resetStore()
+	store["abc"] = map[string]string{"otp_flow_id": "123"}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", nil)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
+	rec := httptest.NewRecorder()
+
+	VerifyOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, "123", rec.Body.String())
+}
+
+func TestVerifyOTP_MissingCookie(t *testing.T) {
+	resetStore()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", nil)
+	rec := httptest.NewRecorder()
+
+	VerifyOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+}
+
+func TestVerifyOTP_UnknownSession(t *testing.T) {
+	resetStore()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", nil)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
+	rec := httptest.NewRecorder()
+
+	VerifyOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+}

--- a/server/internal/routes/otp_test.go
+++ b/server/internal/routes/otp_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/String-sg/teacher-workspace/server/internal/config"
 	"github.com/String-sg/teacher-workspace/server/pkg/require"
 )
 
@@ -14,13 +15,14 @@ func resetStore() {
 }
 
 func TestRequestOTP_WithCookie(t *testing.T) {
+	h := &Handler{cfg: config.Default()}
 	resetStore()
 
 	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", strings.NewReader("yes"))
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
 
-	RequestOTP(rec, req)
+	h.RequestOTP(rec, req)
 
 	res := rec.Result()
 	require.Equal(t, http.StatusOK, res.StatusCode)
@@ -42,12 +44,13 @@ func TestRequestOTP_WithCookie(t *testing.T) {
 }
 
 func TestRequestOTP_NoCookie(t *testing.T) {
+	h := &Handler{cfg: config.Default()}
 	resetStore()
 
 	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", strings.NewReader("yes"))
 	rec := httptest.NewRecorder()
 
-	RequestOTP(rec, req)
+	h.RequestOTP(rec, req)
 
 	res := rec.Result()
 	require.Equal(t, http.StatusOK, res.StatusCode)
@@ -72,6 +75,7 @@ func TestRequestOTP_NoCookie(t *testing.T) {
 }
 
 func TestVerifyOTP_KnownSession(t *testing.T) {
+	h := &Handler{cfg: config.Default()}
 	resetStore()
 	store["abc"] = map[string]string{"otp_flow_id": "123"}
 
@@ -79,7 +83,7 @@ func TestVerifyOTP_KnownSession(t *testing.T) {
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
 
-	VerifyOTP(rec, req)
+	h.VerifyOTP(rec, req)
 
 	res := rec.Result()
 	require.Equal(t, http.StatusOK, res.StatusCode)
@@ -87,25 +91,27 @@ func TestVerifyOTP_KnownSession(t *testing.T) {
 }
 
 func TestVerifyOTP_MissingCookie(t *testing.T) {
+	h := &Handler{cfg: config.Default()}
 	resetStore()
 
 	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", nil)
 	rec := httptest.NewRecorder()
 
-	VerifyOTP(rec, req)
+	h.VerifyOTP(rec, req)
 
 	res := rec.Result()
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
 }
 
 func TestVerifyOTP_UnknownSession(t *testing.T) {
+	h := &Handler{cfg: config.Default()}
 	resetStore()
 
 	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", nil)
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
 
-	VerifyOTP(rec, req)
+	h.VerifyOTP(rec, req)
 
 	res := rec.Result()
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)

--- a/server/internal/routes/otp_test.go
+++ b/server/internal/routes/otp_test.go
@@ -22,18 +22,20 @@ type RoundTripperFunc func(*http.Request) (*http.Response, error)
 func (f RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
 }
-func TestRequestOTP_Success(t *testing.T) {
+func TestRequestOTP_SuccessProduction(t *testing.T) {
 	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(`{"id": "123"}`)))}, nil
 	})
 
-	h := &Handler{cfg: config.Default(), client: &http.Client{Transport: rt}}
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentProduction
+	h := &Handler{cfg: cfg, client: &http.Client{Transport: rt}}
 	resetStore()
 
 	payload := map[string]string{"email": "test@schools.gov.sg"}
 	b, _ := json.Marshal(payload)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/otp/request", bytes.NewReader(b))
 
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
@@ -42,7 +44,55 @@ func TestRequestOTP_Success(t *testing.T) {
 
 	res := rec.Result()
 
-	require.Equal(t, http.StatusNoContent, res.StatusCode)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	var gotOTPResponse requestOTPResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &gotOTPResponse))
+	require.Equal(t, "123", gotOTPResponse.ID)
+
+	// Should set/refresh the same cookie value.
+	var got *http.Cookie
+	for _, c := range res.Cookies() {
+		if c.Name == "session_id" {
+			got = c
+			break
+		}
+	}
+	require.True(t, got != nil)
+	require.Equal(t, "abc", got.Value)
+
+	session, ok := store["abc"]
+	require.True(t, ok)
+	require.Equal(t, "123", session["otp_flow_id"])
+}
+
+func TestRequestOTP_SuccessDevelopment(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(`{"id": "123"}`)))}, nil
+	})
+
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentDevelopment
+	h := &Handler{cfg: cfg, client: &http.Client{Transport: rt}}
+	resetStore()
+
+	payload := map[string]string{"email": "test@tech.gov.sg"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/otp/request", bytes.NewReader(b))
+
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
+	rec := httptest.NewRecorder()
+
+	h.RequestOTP(rec, req)
+
+	res := rec.Result()
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	var gotOTPResponse requestOTPResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &gotOTPResponse))
+	require.Equal(t, "123", gotOTPResponse.ID)
 
 	// Should set/refresh the same cookie value.
 	var got *http.Cookie
@@ -64,7 +114,7 @@ func TestRequestOTP_MissingEmail(t *testing.T) {
 	h := &Handler{cfg: config.Default(), client: &http.Client{}}
 	resetStore()
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", nil)
+	req := httptest.NewRequest(http.MethodPost, "/otp/request", nil)
 	rec := httptest.NewRecorder()
 
 	h.RequestOTP(rec, req)
@@ -72,7 +122,7 @@ func TestRequestOTP_MissingEmail(t *testing.T) {
 	res := rec.Result()
 	require.Equal(t, http.StatusBadRequest, res.StatusCode)
 
-	var got ErrorResponseNoErrors
+	var got errorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Equal(t, "INVALID_FORM", got.Code)
 	require.Equal(t, "One or more input has an error", got.Message)
@@ -85,15 +135,38 @@ func TestRequestOTP_InvalidEmail(t *testing.T) {
 	payload := map[string]string{"email": "test@example.com"}
 	b, _ := json.Marshal(payload)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/otp/request", bytes.NewReader(b))
 	rec := httptest.NewRecorder()
 
 	h.RequestOTP(rec, req)
 
 	res := rec.Result()
-	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
 
-	var got ErrorResponseNoErrors
+	var got errorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, "INVALID_FORM", got.Code)
+	require.Equal(t, "One or more input has an error", got.Message)
+}
+
+func TestRequestOTP_InvalidEmailProduction(t *testing.T) {
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentProduction
+	h := &Handler{cfg: cfg, client: &http.Client{}}
+	resetStore()
+
+	payload := map[string]string{"email": "test@tech.gov.sg"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/otp/request", bytes.NewReader(b))
+	rec := httptest.NewRecorder()
+
+	h.RequestOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
+
+	var got errorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Equal(t, "INVALID_FORM", got.Code)
 	require.Equal(t, "One or more input has an error", got.Message)
@@ -118,7 +191,7 @@ func TestRequestOTP_Timeout(t *testing.T) {
 	payload := map[string]string{"email": "test@schools.gov.sg"}
 	b, _ := json.Marshal(payload)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/otp/request", bytes.NewReader(b))
 
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
@@ -127,13 +200,9 @@ func TestRequestOTP_Timeout(t *testing.T) {
 
 	res := rec.Result()
 
-	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
-
-	var got ErrorResponseNoErrors
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	require.Equal(t, "INTERNAL_SERVER_ERROR", got.Code)
-	require.Equal(t, "Internal server error", got.Message)
-
+	require.Equal(t, http.StatusGatewayTimeout, res.StatusCode)
+	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get("Content-Type"))
+	require.Equal(t, "Request timeout. Please try again later.\n", rec.Body.String())
 }
 
 func TestRequestOTP_NotAuthorized(t *testing.T) {
@@ -147,7 +216,7 @@ func TestRequestOTP_NotAuthorized(t *testing.T) {
 	payload := map[string]string{"email": "test@schools.gov.sg"}
 	b, _ := json.Marshal(payload)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/otp/request", bytes.NewReader(b))
 	rec := httptest.NewRecorder()
 
 	h.RequestOTP(rec, req)
@@ -155,11 +224,8 @@ func TestRequestOTP_NotAuthorized(t *testing.T) {
 	res := rec.Result()
 
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
-
-	var got ErrorResponseNoErrors
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	require.Equal(t, "AUTHORIZATION_FAILED", got.Code)
-	require.Equal(t, "Something went wrong. Please try again later.", got.Message)
+	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get("Content-Type"))
+	require.Equal(t, "Something went wrong. Please try again later.\n", rec.Body.String())
 }
 
 func TestRequestOTP_InternalServerError(t *testing.T) {
@@ -173,18 +239,15 @@ func TestRequestOTP_InternalServerError(t *testing.T) {
 	payload := map[string]string{"email": "test@schools.gov.sg"}
 	b, _ := json.Marshal(payload)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/otp/request", bytes.NewReader(b))
 	rec := httptest.NewRecorder()
 
 	h.RequestOTP(rec, req)
 
 	res := rec.Result()
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
-
-	var got ErrorResponseNoErrors
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	require.Equal(t, "AUTHORIZATION_FAILED", got.Code)
-	require.Equal(t, "Something went wrong. Please try again later.", got.Message)
+	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get("Content-Type"))
+	require.Equal(t, "Something went wrong. Please try again later.\n", rec.Body.String())
 }
 
 func TestRequestOTP_MissingOTPFlowID(t *testing.T) {
@@ -198,18 +261,15 @@ func TestRequestOTP_MissingOTPFlowID(t *testing.T) {
 	payload := map[string]string{"email": "test@schools.gov.sg"}
 	b, _ := json.Marshal(payload)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/request", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/otp/request", bytes.NewReader(b))
 	rec := httptest.NewRecorder()
 
 	h.RequestOTP(rec, req)
 
 	res := rec.Result()
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
-
-	var got ErrorResponseNoErrors
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	require.Equal(t, "INTERNAL_SERVER_ERROR", got.Code)
-	require.Equal(t, "Internal server error", got.Message)
+	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get("Content-Type"))
+	require.Equal(t, "Internal server error\n", rec.Body.String())
 
 	cookies := res.Cookies()
 	require.True(t, len(cookies) == 0)
@@ -227,7 +287,7 @@ func TestVerifyOTP_Success(t *testing.T) {
 	payload := map[string]string{"pin": "123456"}
 	b, _ := json.Marshal(payload)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/otp/verify", bytes.NewReader(b))
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
 
@@ -237,31 +297,13 @@ func TestVerifyOTP_Success(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, res.StatusCode)
 }
 
-func TestVerifyOTP_MissingCookie(t *testing.T) {
-	h := &Handler{cfg: config.Default()}
-	resetStore()
-
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", nil)
-	rec := httptest.NewRecorder()
-
-	h.VerifyOTP(rec, req)
-
-	res := rec.Result()
-	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
-
-	var got ErrorResponseNoErrors
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	require.Equal(t, "INTERNAL_SERVER_ERROR", got.Code)
-	require.Equal(t, "Internal server error", got.Message)
-}
-
 func TestVerifyOTP_MissingPin(t *testing.T) {
 	h := &Handler{cfg: config.Default()}
 	resetStore()
 
 	store["abc"] = map[string]string{"otp_flow_id": "123"}
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", nil)
+	req := httptest.NewRequest(http.MethodPost, "/otp/verify", nil)
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
 
@@ -270,7 +312,7 @@ func TestVerifyOTP_MissingPin(t *testing.T) {
 	res := rec.Result()
 	require.Equal(t, http.StatusBadRequest, res.StatusCode)
 
-	var got ErrorResponseNoErrors
+	var got errorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Equal(t, "INVALID_FORM", got.Code)
 	require.Equal(t, "One or more input has an error", got.Message)
@@ -285,19 +327,37 @@ func TestVerifyOTP_InvalidPin(t *testing.T) {
 	payload := map[string]string{"pin": "1234567"}
 	b, _ := json.Marshal(payload)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/otp/verify", bytes.NewReader(b))
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
 
 	h.VerifyOTP(rec, req)
 
 	res := rec.Result()
-	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
 
-	var got ErrorResponseNoErrors
+	var got errorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Equal(t, "INVALID_FORM", got.Code)
 	require.Equal(t, "One or more input has an error", got.Message)
+}
+
+func TestVerifyOTP_MissingCookie(t *testing.T) {
+	h := &Handler{cfg: config.Default()}
+	resetStore()
+
+	payload := map[string]string{"pin": "123456"}
+	b, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/otp/verify", bytes.NewReader(b))
+	rec := httptest.NewRecorder()
+
+	h.VerifyOTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get("Content-Type"))
+	require.Equal(t, "Internal server error\n", rec.Body.String())
 }
 
 func TestVerifyOTP_MissingSession(t *testing.T) {
@@ -311,7 +371,7 @@ func TestVerifyOTP_MissingSession(t *testing.T) {
 	payload := map[string]string{"pin": "123456"}
 	b, _ := json.Marshal(payload)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/otp/verify", bytes.NewReader(b))
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
 
@@ -320,7 +380,7 @@ func TestVerifyOTP_MissingSession(t *testing.T) {
 	res := rec.Result()
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
 
-	var got ErrorResponseNoErrors
+	var got errorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Equal(t, "AUTHORIZATION_FAILED", got.Code)
 	require.Equal(t, "Failed to authenticate session.", got.Message)
@@ -346,19 +406,16 @@ func TestVerifyOTP_Timeout(t *testing.T) {
 	payload := map[string]string{"pin": "123456"}
 	b, _ := json.Marshal(payload)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/otp/verify", bytes.NewReader(b))
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
 
 	h.VerifyOTP(rec, req)
 
 	res := rec.Result()
-	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
-
-	var got ErrorResponseNoErrors
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	require.Equal(t, "INTERNAL_SERVER_ERROR", got.Code)
-	require.Equal(t, "Internal server error", got.Message)
+	require.Equal(t, http.StatusGatewayTimeout, res.StatusCode)
+	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get("Content-Type"))
+	require.Equal(t, "Request timeout. Please try again later.\n", rec.Body.String())
 }
 
 func TestVerifyOTP_Unauthorized(t *testing.T) {
@@ -374,16 +431,16 @@ func TestVerifyOTP_Unauthorized(t *testing.T) {
 	payload := map[string]string{"pin": "123456"}
 	b, _ := json.Marshal(payload)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/otp/verify", bytes.NewReader(b))
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
 
 	h.VerifyOTP(rec, req)
 
 	res := rec.Result()
-	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	require.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
 
-	var got ErrorResponseNoErrors
+	var got errorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Equal(t, "AUTHORIZATION_FAILED", got.Code)
 	require.Equal(t, "Failed to authenticate session.", got.Message)
@@ -402,44 +459,16 @@ func TestVerifyOTP_NotFound(t *testing.T) {
 	payload := map[string]string{"pin": "123456"}
 	b, _ := json.Marshal(payload)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/otp/verify", bytes.NewReader(b))
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
 
 	h.VerifyOTP(rec, req)
 
 	res := rec.Result()
-	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	require.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
 
-	var got ErrorResponseNoErrors
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	require.Equal(t, "AUTHORIZATION_FAILED", got.Code)
-	require.Equal(t, "Failed to authenticate session.", got.Message)
-}
-
-func TestVerifyOTP_Gone(t *testing.T) {
-	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		return &http.Response{StatusCode: http.StatusGone, Body: io.NopCloser(bytes.NewReader([]byte(`{}`)))}, nil
-	})
-
-	h := &Handler{cfg: config.Default(), client: &http.Client{Transport: rt}}
-	resetStore()
-
-	store["abc"] = map[string]string{"otp_flow_id": "123"}
-
-	payload := map[string]string{"pin": "123456"}
-	b, _ := json.Marshal(payload)
-
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
-	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
-	rec := httptest.NewRecorder()
-
-	h.VerifyOTP(rec, req)
-
-	res := rec.Result()
-	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-
-	var got ErrorResponseNoErrors
+	var got errorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Equal(t, "AUTHORIZATION_FAILED", got.Code)
 	require.Equal(t, "Failed to authenticate session.", got.Message)
@@ -458,7 +487,7 @@ func TestVerifyOTP_BadRequest(t *testing.T) {
 	payload := map[string]string{"pin": "123456"}
 	b, _ := json.Marshal(payload)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/otp/verify", bytes.NewReader(b))
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
 
@@ -466,11 +495,8 @@ func TestVerifyOTP_BadRequest(t *testing.T) {
 
 	res := rec.Result()
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
-
-	var got ErrorResponseNoErrors
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	require.Equal(t, "INTERNAL_SERVER_ERROR", got.Code)
-	require.Equal(t, "Internal server error", got.Message)
+	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get("Content-Type"))
+	require.Equal(t, "Internal server error\n", rec.Body.String())
 }
 
 func TestVerifyOTP_InternalServerError(t *testing.T) {
@@ -486,7 +512,7 @@ func TestVerifyOTP_InternalServerError(t *testing.T) {
 	payload := map[string]string{"pin": "123456"}
 	b, _ := json.Marshal(payload)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/otp/verify", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/otp/verify", bytes.NewReader(b))
 	req.AddCookie(&http.Cookie{Name: "session_id", Value: "abc"})
 	rec := httptest.NewRecorder()
 
@@ -494,9 +520,6 @@ func TestVerifyOTP_InternalServerError(t *testing.T) {
 
 	res := rec.Result()
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
-
-	var got ErrorResponseNoErrors
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	require.Equal(t, "INTERNAL_SERVER_ERROR", got.Code)
-	require.Equal(t, "Internal server error", got.Message)
+	require.Equal(t, "text/plain; charset=utf-8", res.Header.Get("Content-Type"))
+	require.Equal(t, "Internal server error\n", rec.Body.String())
 }

--- a/server/internal/routes/routes.go
+++ b/server/internal/routes/routes.go
@@ -7,12 +7,13 @@ import (
 )
 
 type Handler struct {
-	cfg *config.Config
+	cfg    *config.Config
+	client *http.Client
 }
 
 // Register attaches all application routes to the provided ServeMux.
 func Register(mux *http.ServeMux, cfg *config.Config) {
-	routes := &Handler{cfg: cfg}
+	routes := &Handler{cfg: cfg, client: &http.Client{Timeout: cfg.Client.Timeout}}
 
 	mux.HandleFunc("/", routes.Index)
 	mux.HandleFunc("POST /api/otp/request", routes.RequestOTP)

--- a/server/internal/routes/routes.go
+++ b/server/internal/routes/routes.go
@@ -1,10 +1,20 @@
 package routes
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/String-sg/teacher-workspace/server/internal/config"
+)
+
+type Handler struct {
+	cfg *config.Config
+}
 
 // Register attaches all application routes to the provided ServeMux.
-func Register(mux *http.ServeMux) {
-	mux.HandleFunc("/", Index)
-	mux.HandleFunc("POST /api/otp/request", RequestOTP)
-	mux.HandleFunc("POST /api/otp/verify", VerifyOTP)
+func Register(mux *http.ServeMux, cfg *config.Config) {
+	routes := &Handler{cfg: cfg}
+
+	mux.HandleFunc("/", routes.Index)
+	mux.HandleFunc("POST /api/otp/request", routes.RequestOTP)
+	mux.HandleFunc("POST /api/otp/verify", routes.VerifyOTP)
 }

--- a/server/internal/routes/routes.go
+++ b/server/internal/routes/routes.go
@@ -5,4 +5,6 @@ import "net/http"
 // Register attaches all application routes to the provided ServeMux.
 func Register(mux *http.ServeMux) {
 	mux.HandleFunc("/", Index)
+	mux.HandleFunc("POST /api/otp/request", RequestOTP)
+	mux.HandleFunc("POST /api/otp/verify", VerifyOTP)
 }

--- a/server/internal/routes/routes.go
+++ b/server/internal/routes/routes.go
@@ -12,8 +12,8 @@ type Handler struct {
 }
 
 // Register attaches all application routes to the provided ServeMux.
-func Register(mux *http.ServeMux, cfg *config.Config) {
-	routes := &Handler{cfg: cfg, client: &http.Client{Timeout: cfg.Client.Timeout}}
+func Register(mux *http.ServeMux, cfg *config.Config, client *http.Client) {
+	routes := &Handler{cfg: cfg, client: client}
 
 	mux.HandleFunc("/", routes.Index)
 	mux.HandleFunc("POST /api/otp/request", routes.RequestOTP)

--- a/server/internal/routes/routes.go
+++ b/server/internal/routes/routes.go
@@ -16,6 +16,6 @@ func Register(mux *http.ServeMux, cfg *config.Config, client *http.Client) {
 	routes := &Handler{cfg: cfg, client: client}
 
 	mux.HandleFunc("/", routes.Index)
-	mux.HandleFunc("POST /api/otp/request", routes.RequestOTP)
-	mux.HandleFunc("POST /api/otp/verify", routes.VerifyOTP)
+	mux.HandleFunc("POST /otp/request", routes.RequestOTP)
+	mux.HandleFunc("POST /otp/verify", routes.VerifyOTP)
 }


### PR DESCRIPTION
Closes #39 

## 🚀 Summary

Adds OTPaaS-backed OTP flows to the server by introducing `/api/otp/request` and `/api/otp/verify`. The routes use a `session_id` cookie to persist the `otp_flow_id`, read OTPaaS credentials from config/env, and return consistent structured JSON error responses (including explicit timeout handling).

## ✏️ Changes

- **Added** OTP request + verify endpoints wired into route registration (`POST /api/otp/request`, `POST /api/otp/verify`).
- **Added** OTP route handler implementation integrating with OTPaaS (auth token/headers, configurable host).
- **Added** session handling via `session_id` cookie and an in-memory store for `otp_flow_id`.
- **Added** structured JSON error responses and expanded error handling for OTPaaS failures and non-200 responses.
- **Added** config support for OTPaaS + configurable HTTP client timeout; passed config into routes (`routes.Register(mux, cfg)`).
- **Changed** successful OTP endpoints to return **204 No Content** (instead of 200).
- **Updated** Index route to be a method on the routes handler to align with the handler struct pattern.
- **Tests** added/expanded OTP route tests and adjusted Index/tests naming.

##  📑 Notes
- Copy pending (UXD): Some log/error messages are placeholder text and will be updated once UXD finalizes copy.
- OTPaaS: Need confirmation on OTPaaS semantics for expired/invalid flows, e.g. should expiry map to 404 Not Found or 410 Gone