### PR TITLE
chore: update go version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: 'go.mod'
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9


### PR DESCRIPTION
## 🚀 Summary

CI was failing because go-version was set to 'stable', set to '1.25.x' to suit out Go version 

## ✏️ Changes

- ci yaml file - specfiically for Go Lint
