### PR TITLE
feat: add standalone OTP service under server/cmd/otp

### DIFF
--- a/server/cmd/otp/config.go
+++ b/server/cmd/otp/config.go
@@ -16,25 +16,25 @@ const (
 )
 
 type ServerConfig struct {
-	Port int `dotenv:"TW_SERVER_PORT"`
+	Port int `dotenv:"OTP_SERVER_PORT"`
 
-	ReadTimeout       time.Duration `dotenv:"TW_SERVER_READ_TIMEOUT"`
-	ReadHeaderTimeout time.Duration `dotenv:"TW_SERVER_READ_HEADER_TIMEOUT"`
-	WriteTimeout      time.Duration `dotenv:"TW_SERVER_WRITE_TIMEOUT"`
-	IdleTimeout       time.Duration `dotenv:"TW_SERVER_IDLE_TIMEOUT"`
+	ReadTimeout       time.Duration `dotenv:"OTP_SERVER_READ_TIMEOUT"`
+	ReadHeaderTimeout time.Duration `dotenv:"OTP_SERVER_READ_HEADER_TIMEOUT"`
+	WriteTimeout      time.Duration `dotenv:"OTP_SERVER_WRITE_TIMEOUT"`
+	IdleTimeout       time.Duration `dotenv:"OTP_SERVER_IDLE_TIMEOUT"`
 }
 
 type OTPaaSConfig struct {
-	Host      string        `dotenv:"TW_OTPAAS_HOST"`
-	AppID     string        `dotenv:"TW_OTPAAS_ID"`
-	Namespace string        `dotenv:"TW_OTPAAS_NAMESPACE"`
-	Secret    string        `dotenv:"TW_OTPAAS_SECRET"`
-	Timeout   time.Duration `dotenv:"TW_OTPAAS_TIMEOUT"`
+	Host         string        `dotenv:"OTP_OTPAAS_HOST"`
+	AppID        string        `dotenv:"OTP_OTPAAS_ID"`
+	AppNamespace string        `dotenv:"OTP_OTPAAS_APP_NAMESPACE"`
+	Secret       string        `dotenv:"OTP_OTPAAS_SECRET"`
+	Timeout      time.Duration `dotenv:"OTP_OTPAAS_TIMEOUT"`
 }
 
 type Config struct {
-	Environment Environment `dotenv:"TW_ENV"`
-	LogLevel    slog.Level  `dotenv:"TW_LOG_LEVEL"`
+	Environment Environment `dotenv:"OTP_ENV"`
+	LogLevel    slog.Level  `dotenv:"OTP_LOG_LEVEL"`
 
 	Server ServerConfig `dotenv:",squash"`
 	OTPaaS OTPaaSConfig `dotenv:",squash"`
@@ -63,35 +63,52 @@ func Default() *Config {
 func (c *Config) Validate() error {
 	var errs []error
 
-	if c.Server.Port < 1 || c.Server.Port > 65535 {
-		errs = append(errs, fmt.Errorf("TW_SERVER_PORT must be between 1 and 65535; got %d", c.Server.Port))
+	if c.Environment != EnvDevelopment && c.Environment != EnvStaging && c.Environment != EnvProduction {
+		errs = append(errs, fmt.Errorf("OTP_ENV must be one of %q, %q or %q; got %q", EnvDevelopment, EnvStaging, EnvProduction, c.Environment))
 	}
-	if c.Server.ReadHeaderTimeout <= 0 {
-		errs = append(errs, fmt.Errorf("TW_SERVER_READ_HEADER_TIMEOUT must be a positive duration; got %v", c.Server.ReadHeaderTimeout))
+
+	return errors.Join(append(errs, c.Server.validate(), c.OTPaaS.validate())...)
+}
+
+func (c ServerConfig) validate() error {
+	var errs []error
+
+	if c.Port < 1 || c.Port > 65535 {
+		errs = append(errs, fmt.Errorf("OTP_SERVER_PORT must be between 1 and 65535; got %d", c.Port))
 	}
-	if c.Server.ReadTimeout <= 0 {
-		errs = append(errs, fmt.Errorf("TW_SERVER_READ_TIMEOUT must be a positive duration; got %v", c.Server.ReadTimeout))
+	if c.ReadHeaderTimeout <= 0 {
+		errs = append(errs, fmt.Errorf("OTP_SERVER_READ_HEADER_TIMEOUT must be a positive duration; got %v", c.ReadHeaderTimeout))
 	}
-	if c.Server.WriteTimeout <= 0 {
-		errs = append(errs, fmt.Errorf("TW_SERVER_WRITE_TIMEOUT must be a positive duration; got %v", c.Server.WriteTimeout))
+	if c.ReadTimeout <= 0 {
+		errs = append(errs, fmt.Errorf("OTP_SERVER_READ_TIMEOUT must be a positive duration; got %v", c.ReadTimeout))
 	}
-	if c.Server.IdleTimeout <= 0 {
-		errs = append(errs, fmt.Errorf("TW_SERVER_IDLE_TIMEOUT must be a positive duration; got %v", c.Server.IdleTimeout))
+	if c.WriteTimeout <= 0 {
+		errs = append(errs, fmt.Errorf("OTP_SERVER_WRITE_TIMEOUT must be a positive duration; got %v", c.WriteTimeout))
 	}
-	if c.OTPaaS.Host == "" {
-		errs = append(errs, errors.New("TW_OTPAAS_HOST is required"))
+	if c.IdleTimeout <= 0 {
+		errs = append(errs, fmt.Errorf("OTP_SERVER_IDLE_TIMEOUT must be a positive duration; got %v", c.IdleTimeout))
 	}
-	if c.OTPaaS.AppID == "" {
-		errs = append(errs, errors.New("TW_OTPAAS_ID is required"))
+
+	return errors.Join(errs...)
+}
+
+func (c OTPaaSConfig) validate() error {
+	var errs []error
+
+	if c.Host == "" {
+		errs = append(errs, errors.New("OTP_OTPAAS_HOST is required"))
 	}
-	if c.OTPaaS.Namespace == "" {
-		errs = append(errs, errors.New("TW_OTPAAS_NAMESPACE is required"))
+	if c.AppID == "" {
+		errs = append(errs, errors.New("OTP_OTPAAS_APP_ID is required"))
 	}
-	if c.OTPaaS.Secret == "" {
-		errs = append(errs, errors.New("TW_OTPAAS_SECRET is required"))
+	if c.AppNamespace == "" {
+		errs = append(errs, errors.New("OTP_OTPAAS_APP_NAMESPACE is required"))
 	}
-	if c.OTPaaS.Timeout <= 0 {
-		errs = append(errs, fmt.Errorf("TW_OTPAAS_TIMEOUT must be positive; got %v", c.OTPaaS.Timeout))
+	if c.Secret == "" {
+		errs = append(errs, errors.New("OTP_OTPAAS_SECRET is required"))
+	}
+	if c.Timeout <= 0 {
+		errs = append(errs, fmt.Errorf("OTP_OTPAAS_TIMEOUT must be a positive duration; got %v", c.Timeout))
 	}
 
 	return errors.Join(errs...)

--- a/server/cmd/otp/config.go
+++ b/server/cmd/otp/config.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+type Environment string
+
+const (
+	EnvDevelopment Environment = "development"
+	EnvStaging     Environment = "staging"
+	EnvProduction  Environment = "production"
+)
+
+type ServerConfig struct {
+	Port int `dotenv:"TW_SERVER_PORT"`
+
+	ReadTimeout       time.Duration `dotenv:"TW_SERVER_READ_TIMEOUT"`
+	ReadHeaderTimeout time.Duration `dotenv:"TW_SERVER_READ_HEADER_TIMEOUT"`
+	WriteTimeout      time.Duration `dotenv:"TW_SERVER_WRITE_TIMEOUT"`
+	IdleTimeout       time.Duration `dotenv:"TW_SERVER_IDLE_TIMEOUT"`
+}
+
+type OTPaaSConfig struct {
+	Host      string        `dotenv:"TW_OTPAAS_HOST"`
+	AppID     string        `dotenv:"TW_OTPAAS_ID"`
+	Namespace string        `dotenv:"TW_OTPAAS_NAMESPACE"`
+	Secret    string        `dotenv:"TW_OTPAAS_SECRET"`
+	Timeout   time.Duration `dotenv:"TW_OTPAAS_TIMEOUT"`
+}
+
+type Config struct {
+	Environment Environment `dotenv:"TW_ENV"`
+	LogLevel    slog.Level  `dotenv:"TW_LOG_LEVEL"`
+
+	Server ServerConfig `dotenv:",squash"`
+	OTPaaS OTPaaSConfig `dotenv:",squash"`
+}
+
+func Default() *Config {
+	return &Config{
+		Environment: EnvDevelopment,
+		LogLevel:    slog.LevelInfo,
+
+		Server: ServerConfig{
+			Port: 3001,
+
+			ReadHeaderTimeout: 2 * time.Second,
+			ReadTimeout:       15 * time.Second,
+			WriteTimeout:      30 * time.Second,
+			IdleTimeout:       60 * time.Second,
+		},
+		OTPaaS: OTPaaSConfig{
+			Host:    "https://otp.techpass.suite.gov.sg",
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+func (c *Config) Validate() error {
+	var errs []error
+
+	if c.Server.Port < 1 || c.Server.Port > 65535 {
+		errs = append(errs, fmt.Errorf("TW_SERVER_PORT must be between 1 and 65535; got %d", c.Server.Port))
+	}
+	if c.Server.ReadHeaderTimeout <= 0 {
+		errs = append(errs, fmt.Errorf("TW_SERVER_READ_HEADER_TIMEOUT must be a positive duration; got %v", c.Server.ReadHeaderTimeout))
+	}
+	if c.Server.ReadTimeout <= 0 {
+		errs = append(errs, fmt.Errorf("TW_SERVER_READ_TIMEOUT must be a positive duration; got %v", c.Server.ReadTimeout))
+	}
+	if c.Server.WriteTimeout <= 0 {
+		errs = append(errs, fmt.Errorf("TW_SERVER_WRITE_TIMEOUT must be a positive duration; got %v", c.Server.WriteTimeout))
+	}
+	if c.Server.IdleTimeout <= 0 {
+		errs = append(errs, fmt.Errorf("TW_SERVER_IDLE_TIMEOUT must be a positive duration; got %v", c.Server.IdleTimeout))
+	}
+	if c.OTPaaS.Host == "" {
+		errs = append(errs, errors.New("TW_OTPAAS_HOST is required"))
+	}
+	if c.OTPaaS.AppID == "" {
+		errs = append(errs, errors.New("TW_OTPAAS_ID is required"))
+	}
+	if c.OTPaaS.Namespace == "" {
+		errs = append(errs, errors.New("TW_OTPAAS_NAMESPACE is required"))
+	}
+	if c.OTPaaS.Secret == "" {
+		errs = append(errs, errors.New("TW_OTPAAS_SECRET is required"))
+	}
+	if c.OTPaaS.Timeout <= 0 {
+		errs = append(errs, fmt.Errorf("TW_OTPAAS_TIMEOUT must be positive; got %v", c.OTPaaS.Timeout))
+	}
+
+	return errors.Join(errs...)
+}

--- a/server/cmd/otp/error.go
+++ b/server/cmd/otp/error.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ErrorResponse represents a structured error response.
+type ErrorResponse struct {
+	Message string       `json:"message"`
+	Errors  []FieldError `json:"errors,omitempty"`
+}
+
+// Error implements [error].
+func (e *ErrorResponse) Error() string {
+	if len(e.Errors) == 0 {
+		return e.Message
+	}
+
+	parts := make([]string, 0, len(e.Errors))
+	for _, fe := range e.Errors {
+		parts = append(parts, fmt.Sprintf("%s: %s", fe.Field, fe.Message))
+	}
+
+	return fmt.Sprintf("%s: %s", e.Message, strings.Join(parts, ", "))
+}
+
+// FieldError represents a single field-level validation error.
+type FieldError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+// Error implements [error].
+func (e *FieldError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
+
+// NewValidationError creates a new validation error response.
+func NewValidationError(errs []FieldError) error {
+	return &ErrorResponse{
+		Message: "Validation Failed",
+		Errors:  errs,
+	}
+}

--- a/server/cmd/otp/handler.go
+++ b/server/cmd/otp/handler.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"net/http"
+)
+
+type Handler struct {
+	cfg    *Config
+	client *http.Client
+}
+
+func Register(mux *http.ServeMux, cfg *Config, client *http.Client) {
+	routes := &Handler{cfg: cfg, client: client}
+
+	mux.HandleFunc("POST /request", routes.Request)
+	mux.HandleFunc("POST /verify/{flow_id}", routes.Verify)
+}

--- a/server/cmd/otp/handler.go
+++ b/server/cmd/otp/handler.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
+
+	"github.com/String-sg/teacher-workspace/server/internal/middleware"
 )
 
 type Handler struct {
@@ -9,9 +12,37 @@ type Handler struct {
 	client *http.Client
 }
 
+const (
+	HeaderContentType         = "Content-Type"
+	HeaderXContentTypeOptions = "X-Content-Type-Options"
+)
+
+const (
+	charsetUTF8                    = "charset=UTF-8"
+	MIMEApplicationJSON            = "application/json"
+	MIMEApplicationJSONCharsetUTF8 = MIMEApplicationJSON + "; " + charsetUTF8
+	MIMETextHTML                   = "text/html"
+	MIMETextHTMLCharsetUTF8        = MIMETextHTML + "; " + charsetUTF8
+	MIMETextPlain                  = "text/plain"
+	MIMETextPlainCharsetUTF8       = MIMETextPlain + "; " + charsetUTF8
+)
+
 func Register(mux *http.ServeMux, cfg *Config, client *http.Client) {
 	routes := &Handler{cfg: cfg, client: client}
 
 	mux.HandleFunc("POST /request", routes.Request)
 	mux.HandleFunc("POST /verify/{flow_id}", routes.Verify)
+}
+
+func (h *Handler) renderJSON(r *http.Request, w http.ResponseWriter, statusCode int, data any) {
+	logger := middleware.LoggerFromContext(r.Context())
+
+	w.Header().Set(HeaderContentType, MIMEApplicationJSONCharsetUTF8)
+	w.Header().Set(HeaderXContentTypeOptions, "nosniff")
+
+	w.WriteHeader(statusCode)
+
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		logger.Warn("failed to write response body", "renderer", "json", "err", err)
+	}
 }

--- a/server/cmd/otp/main.go
+++ b/server/cmd/otp/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/String-sg/teacher-workspace/server/internal/middleware"
+	"github.com/String-sg/teacher-workspace/server/pkg/dotenv"
+)
+
+func main() {
+	level := new(slog.LevelVar)
+	level.Set(slog.LevelInfo)
+
+	h := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: level,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				return slog.String(slog.TimeKey, a.Value.Time().Format(time.RFC3339))
+			}
+
+			return a
+		},
+	})
+
+	slog.SetDefault(slog.New(h))
+
+	cfg := Default()
+	if err := dotenv.Load(cfg); err != nil {
+		slog.Error("failed to load environment config", "err", err)
+		os.Exit(1)
+	}
+	if err := cfg.Validate(); err != nil {
+		slog.Error("invalid configuration", "err", err)
+		os.Exit(1)
+	}
+
+	level.Set(cfg.LogLevel)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if err := run(ctx, cfg); err != nil {
+		slog.Error("server exited", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, cfg *Config) error {
+	client := &http.Client{Timeout: cfg.OTPaaS.Timeout}
+	mux := http.NewServeMux()
+	Register(mux, cfg, client)
+
+	app := middleware.Chain(mux, middleware.RequestID)
+	addr := fmt.Sprintf(":%d", cfg.Server.Port)
+
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           app,
+		ReadTimeout:       cfg.Server.ReadTimeout,
+		ReadHeaderTimeout: cfg.Server.ReadHeaderTimeout,
+		WriteTimeout:      cfg.Server.WriteTimeout,
+		IdleTimeout:       cfg.Server.IdleTimeout,
+	}
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		slog.Info("server listening", slog.String("address", server.Addr))
+		errCh <- server.ListenAndServe()
+	}()
+
+	select {
+	case <-ctx.Done():
+		slog.Info("server shutting down")
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return err
+		}
+
+		return nil
+
+	case err := <-errCh:
+		if err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	}
+}

--- a/server/cmd/otp/main.go
+++ b/server/cmd/otp/main.go
@@ -47,7 +47,7 @@ func main() {
 	defer cancel()
 
 	if err := run(ctx, cfg); err != nil {
-		slog.Error("server exited", "err", err)
+		slog.Error("server exited unexpectedly", "err", err)
 		os.Exit(1)
 	}
 }

--- a/server/cmd/otp/otp.go
+++ b/server/cmd/otp/otp.go
@@ -9,7 +9,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"strings"
 
@@ -22,29 +24,6 @@ const (
 	ErrorCodeInternalServerError = "INTERNAL_SERVER_ERROR"
 	ErrorCodeRequestTimeout      = "REQUEST_TIMEOUT"
 )
-
-type errorResponse struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-}
-
-func writeErrorResponse(w http.ResponseWriter, status int, code, message string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-
-	_ = json.NewEncoder(w).Encode(errorResponse{
-		Code:    code,
-		Message: message,
-	})
-}
-
-type requestOTPRequest struct {
-	Email string `json:"email"`
-}
-
-type requestOTPResponse struct {
-	ID string `json:"id"`
-}
 
 func buildAuthToken(appID, appNamespace, appSecret string) string {
 	mac := hmac.New(sha256.New, []byte(appSecret))
@@ -61,116 +40,156 @@ func isAllowedEmail(email string, env Environment) bool {
 	return strings.HasSuffix(email, "@schools.gov.sg") || strings.HasSuffix(email, "@tech.gov.sg")
 }
 
-func isValidEmailFormat(email string) bool {
-	email = strings.TrimSpace(email)
-	if len(email) < 5 || len(email) > 254 {
-		return false
-	}
-	return strings.Contains(email, "@")
-}
-
 // ------------------------------------------- REQUEST OTP -------------------------------------------
+
 func (h *Handler) Request(w http.ResponseWriter, r *http.Request) {
 	logger := middleware.LoggerFromContext(r.Context())
 
-	ct := r.Header.Get("Content-Type")
-	if !strings.HasPrefix(ct, "application/json") {
-		writeErrorResponse(w, http.StatusUnsupportedMediaType, ErrorCodeInvalidForm, "Content-Type must be application/json")
-		logger.Error("Content-Type must be application/json", "content_type", ct)
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get(HeaderContentType))
+	if err != nil || mediaType != MIMEApplicationJSON {
+		h.renderJSON(r, w, http.StatusUnsupportedMediaType, ErrorResponse{
+			Message: http.StatusText(http.StatusUnsupportedMediaType),
+		})
 		return
 	}
 
-	var body requestOTPRequest
+	var body struct {
+		Email string `json:"email"`
+	}
+
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeErrorResponse(w, http.StatusBadRequest, ErrorCodeInvalidForm, "One or more input has an error")
-		logger.Error("email not found in request body", "err", err)
+		h.renderJSON(r, w, http.StatusBadRequest, ErrorResponse{
+			Message: "One or more input has an error",
+		})
 		return
 	}
 
 	body.Email = strings.TrimSpace(body.Email)
 	if body.Email == "" {
-		writeErrorResponse(w, http.StatusUnprocessableEntity, ErrorCodeInvalidForm, "One or more input has an error")
-		logger.Error("email required in request body")
-		return
-	}
-
-	if !isValidEmailFormat(body.Email) {
-		writeErrorResponse(w, http.StatusUnprocessableEntity, ErrorCodeInvalidForm, "One or more input has an error")
-		logger.Error("email not a valid email format")
+		h.renderJSON(r, w, http.StatusUnprocessableEntity, ErrorResponse{
+			Message: "One or more input has an error",
+		})
 		return
 	}
 
 	if !isAllowedEmail(body.Email, h.cfg.Environment) {
-		writeErrorResponse(w, http.StatusUnprocessableEntity, ErrorCodeInvalidForm, "One or more input has an error")
-		logger.Error("email not a valid schools.gov.sg email")
+		h.renderJSON(r, w, http.StatusUnprocessableEntity, ErrorResponse{
+			Message: "One or more input has an error",
+		})
 		return
 	}
 
 	payload, err := json.Marshal(map[string]string{"email": body.Email})
 	if err != nil {
-		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Internal server error")
+		h.renderJSON(r, w, http.StatusInternalServerError, ErrorResponse{
+			Message: "Internal server error",
+		})
 		logger.Error("failed to marshal request body", "err", err)
 		return
 	}
 
 	req, err := http.NewRequest(http.MethodPost, h.cfg.OTPaaS.Host+"/otp", bytes.NewReader(payload))
 	if err != nil {
-		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Internal server error")
+		h.renderJSON(r, w, http.StatusInternalServerError, ErrorResponse{
+			Message: "Internal server error",
+		})
 		logger.Error("failed to create request", "err", err)
 		return
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+buildAuthToken(h.cfg.OTPaaS.AppID, h.cfg.OTPaaS.Namespace, h.cfg.OTPaaS.Secret))
+	req.Header.Set("Authorization", "Bearer "+buildAuthToken(h.cfg.OTPaaS.AppID, h.cfg.OTPaaS.AppNamespace, h.cfg.OTPaaS.Secret))
 	req.Header.Set("X-App-Id", h.cfg.OTPaaS.AppID)
-	req.Header.Set("X-App-Namespace", h.cfg.OTPaaS.Namespace)
+	req.Header.Set("X-App-Namespace", h.cfg.OTPaaS.AppNamespace)
 
 	resp, err := h.client.Do(req)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			writeErrorResponse(w, http.StatusGatewayTimeout, ErrorCodeRequestTimeout, "Request timeout. Please try again later.")
+			h.renderJSON(r, w, http.StatusGatewayTimeout, ErrorResponse{
+				Message: "Request timeout. Please try again later.",
+			})
 			logger.Error("OTPaas request timeout", "err", err)
 			return
 		}
-		writeErrorResponse(w, http.StatusBadGateway, ErrorCodeInternalServerError, "Internal server error")
+		h.renderJSON(r, w, http.StatusInternalServerError, ErrorResponse{
+			Message: "Internal server error",
+		})
 		logger.Error("error sending request to OTPaas", "err", err)
 		return
 	}
 
-	if resp.StatusCode == http.StatusTooManyRequests {
-		writeErrorResponse(w, http.StatusTooManyRequests, ErrorCodeInternalServerError, "OTPaas rate limited")
-		logger.Error("otpaas rate limited", "otpaas_status_code", resp.StatusCode)
-		return
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Internal server error")
-		logger.Error("authorization failed", "otpaas_status_code", resp.StatusCode)
-		return
-	}
-
 	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			logger.Error("failed to close response body", "err", err)
-		}
+		_ = resp.Body.Close()
 	}()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Internal server error")
+		h.renderJSON(r, w, http.StatusInternalServerError, ErrorResponse{
+			Message: "Internal server error",
+		})
 		logger.Error("failed to read response body", "err", err, "otpaas_status_code", resp.StatusCode)
 		return
 	}
 
-	var otpResp requestOTPResponse
+	if resp.StatusCode != http.StatusOK {
+		var detail struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(bodyBytes, &detail)
+
+		switch resp.StatusCode {
+		case http.StatusBadRequest:
+			if detail.Code == 2008 {
+				h.renderJSON(r, w, http.StatusTooManyRequests, ErrorResponse{
+					Message: "Too many requests. Please try again later.",
+				})
+				return
+			}
+			h.renderJSON(r, w, http.StatusBadRequest, ErrorResponse{
+				Message: fmt.Sprintf("Bad request (code %d): %q", detail.Code, detail.Message),
+			})
+			return
+		case http.StatusUnauthorized:
+			h.renderJSON(r, w, http.StatusUnauthorized, ErrorResponse{
+				Message: "Unauthorized",
+			})
+			return
+		case http.StatusForbidden:
+			if detail.Code == 2005 {
+				h.renderJSON(r, w, http.StatusForbidden, ErrorResponse{
+					Message: "Forbidden",
+				})
+				return
+			}
+			h.renderJSON(r, w, http.StatusForbidden, ErrorResponse{
+				Message: fmt.Sprintf("Forbidden (code %d): %q", detail.Code, detail.Message),
+			})
+			return
+		default:
+			h.renderJSON(r, w, http.StatusInternalServerError, ErrorResponse{
+				Message: fmt.Sprintf("Unexpected status %d (code %d): %q", resp.StatusCode, detail.Code, detail.Message),
+			})
+			return
+		}
+	}
+
+	var otpResp struct {
+		ID string `json:"id"`
+	}
+
 	if err := json.Unmarshal(bodyBytes, &otpResp); err != nil {
-		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Invalid OTPaas response")
+		h.renderJSON(r, w, http.StatusInternalServerError, ErrorResponse{
+			Message: "Invalid OTPaas response",
+		})
 		logger.Error("failed to unmarshal response body", "err", err, "otpaas_status_code", resp.StatusCode)
 		return
 	}
 
 	if otpResp.ID == "" {
-		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Missing id from OTPaas")
+		h.renderJSON(r, w, http.StatusInternalServerError, ErrorResponse{
+			Message: "Missing id from OTPaas",
+		})
 		logger.Error("failed to get id from OTPaas", "otpaas_status_code", resp.StatusCode)
 		return
 	}
@@ -179,108 +198,132 @@ func (h *Handler) Request(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 
 	if err := json.NewEncoder(w).Encode(map[string]string{"flow_id": otpResp.ID}); err != nil {
-		logger.Error("failed to encode response", "err", err)
+		logger.Warn("failed to encode response", "err", err)
 	}
 }
 
 // ------------------------------------------- VERIFY OTP -------------------------------------------
 
-type verifyOTPRequest struct {
-	PIN string `json:"pin"`
-}
-
 func (h *Handler) Verify(w http.ResponseWriter, r *http.Request) {
 	logger := middleware.LoggerFromContext(r.Context())
 
 	flowID := r.PathValue("flow_id")
-	if flowID == "" {
-		writeErrorResponse(w, http.StatusBadRequest, ErrorCodeInvalidForm, "One or more input has an error")
-		logger.Error("flow_id is required")
+
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get(HeaderContentType))
+	if err != nil || mediaType != MIMEApplicationJSON {
+		h.renderJSON(r, w, http.StatusUnsupportedMediaType, ErrorResponse{
+			Message: http.StatusText(http.StatusUnsupportedMediaType),
+		})
 		return
 	}
 
-	ct := r.Header.Get("Content-Type")
-	if !strings.HasPrefix(ct, "application/json") {
-		writeErrorResponse(w, http.StatusUnsupportedMediaType, ErrorCodeInvalidForm, "Content-Type must be application/json")
-		logger.Error("Content-Type must be application/json", "content_type", ct)
-		return
+	var body struct {
+		PIN string `json:"pin"`
 	}
 
-	var body verifyOTPRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeErrorResponse(w, http.StatusBadRequest, ErrorCodeInvalidForm, "One or more input has an error")
-		logger.Error("pin not found in request body", "err", err)
+		h.renderJSON(r, w, http.StatusBadRequest, ErrorResponse{
+			Message: "One or more input has an error",
+		})
 		return
 	}
 
 	if body.PIN == "" {
-		writeErrorResponse(w, http.StatusUnprocessableEntity, ErrorCodeInvalidForm, "One or more input has an error")
-		logger.Error("pin is required")
+		h.renderJSON(r, w, http.StatusUnprocessableEntity, ErrorResponse{
+			Message: "One or more input has an error",
+		})
 		return
 	}
 	if len(body.PIN) != 6 {
-		writeErrorResponse(w, http.StatusUnprocessableEntity, ErrorCodeInvalidForm, "One or more input has an error")
-		logger.Error("pin is not a valid 6 digit PIN")
+		h.renderJSON(r, w, http.StatusUnprocessableEntity, ErrorResponse{
+			Message: "One or more input has an error",
+		})
 		return
 	}
 
 	payload, err := json.Marshal(map[string]string{"pin": body.PIN})
 	if err != nil {
-		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Internal server error")
+		h.renderJSON(r, w, http.StatusInternalServerError, ErrorResponse{
+			Message: "Internal server error",
+		})
 		logger.Error("failed to marshal request body", "err", err)
 		return
 	}
 
 	req, err := http.NewRequest("PUT", h.cfg.OTPaaS.Host+"/otp/"+flowID, bytes.NewReader(payload))
 	if err != nil {
-		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Internal server error")
+		h.renderJSON(r, w, http.StatusInternalServerError, ErrorResponse{
+			Message: "Internal server error",
+		})
 		logger.Error("failed to create request", "err", err)
 		return
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+buildAuthToken(h.cfg.OTPaaS.AppID, h.cfg.OTPaaS.Namespace, h.cfg.OTPaaS.Secret))
+	req.Header.Set("Authorization", "Bearer "+buildAuthToken(h.cfg.OTPaaS.AppID, h.cfg.OTPaaS.AppNamespace, h.cfg.OTPaaS.Secret))
 	req.Header.Set("X-App-Id", h.cfg.OTPaaS.AppID)
-	req.Header.Set("X-App-Namespace", h.cfg.OTPaaS.Namespace)
+	req.Header.Set("X-App-Namespace", h.cfg.OTPaaS.AppNamespace)
 
 	resp, err := h.client.Do(req)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			writeErrorResponse(w, http.StatusGatewayTimeout, ErrorCodeRequestTimeout, "Request timeout. Please try again later.")
+			h.renderJSON(r, w, http.StatusGatewayTimeout, ErrorResponse{
+				Message: "Request timeout. Please try again later.",
+			})
 			logger.Error("OTPaas request timeout", "err", err)
 			return
 		}
-		writeErrorResponse(w, http.StatusBadGateway, ErrorCodeInternalServerError, "Internal server error")
+		h.renderJSON(r, w, http.StatusBadGateway, ErrorResponse{
+			Message: "Internal server error",
+		})
 		logger.Error("error sending request to OTPaas", "err", err)
 		return
 	}
 
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
 	if resp.StatusCode != http.StatusOK {
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			h.renderJSON(r, w, http.StatusInternalServerError, ErrorResponse{
+				Message: "Internal server error",
+			})
+			logger.Error("failed to read response body", "err", err, "otpaas_status_code", resp.StatusCode)
+			return
+		}
+
+		var detail struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(respBody, &detail)
+
 		switch resp.StatusCode {
 		case http.StatusUnauthorized:
-			writeErrorResponse(w, http.StatusUnprocessableEntity, ErrorCodeAuth, "Failed to authenticate session.")
-			logger.Error("invalid PIN", "otpaas_status_code", resp.StatusCode)
+			if detail.Code == 1006 {
+				h.renderJSON(r, w, http.StatusUnprocessableEntity, ErrorResponse{
+					Message: "Invalid PIN",
+				})
+				return
+			}
+			h.renderJSON(r, w, http.StatusUnauthorized, ErrorResponse{
+				Message: "Unauthorized",
+			})
 			return
 		case http.StatusNotFound:
-			writeErrorResponse(w, http.StatusNotFound, ErrorCodeAuth, "Failed to authenticate session.")
-			logger.Error("pin expired", "otpaas_status_code", resp.StatusCode)
-			return
-		case http.StatusTooManyRequests:
-			writeErrorResponse(w, http.StatusTooManyRequests, ErrorCodeAuth, "Too many verification attempts.")
-			logger.Error("OTPaas rate limited", "otpaas_status_code", resp.StatusCode)
+			h.renderJSON(r, w, http.StatusNotFound, ErrorResponse{
+				Message: "Flow expired",
+			})
 			return
 		default:
-			writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Internal server error")
-			logger.Error("internal server error", "otpaas_status_code", resp.StatusCode)
+			h.renderJSON(r, w, http.StatusInternalServerError, ErrorResponse{
+				Message: fmt.Sprintf("Unexpected status %d (code %d): %q", resp.StatusCode, detail.Code, detail.Message),
+			})
 			return
 		}
 	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			logger.Error("failed to close response body", "err", err)
-		}
-	}()
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/server/cmd/otp/otp.go
+++ b/server/cmd/otp/otp.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/String-sg/teacher-workspace/server/internal/middleware"
+)
+
+const (
+	ErrorCodeInvalidForm         = "INVALID_FORM"
+	ErrorCodeAuth                = "AUTHORIZATION_FAILED"
+	ErrorCodeInternalServerError = "INTERNAL_SERVER_ERROR"
+	ErrorCodeRequestTimeout      = "REQUEST_TIMEOUT"
+)
+
+type errorResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func writeErrorResponse(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	_ = json.NewEncoder(w).Encode(errorResponse{
+		Code:    code,
+		Message: message,
+	})
+}
+
+type requestOTPRequest struct {
+	Email string `json:"email"`
+}
+
+type requestOTPResponse struct {
+	ID string `json:"id"`
+}
+
+func buildAuthToken(appID, appNamespace, appSecret string) string {
+	mac := hmac.New(sha256.New, []byte(appSecret))
+	mac.Write([]byte(appID))
+	sig := hex.EncodeToString(mac.Sum(nil))
+	payload := appNamespace + ":" + appID + ":" + sig
+	return base64.StdEncoding.EncodeToString([]byte(payload))
+}
+
+func isAllowedEmail(email string, env Environment) bool {
+	if env == EnvProduction {
+		return strings.HasSuffix(email, "@schools.gov.sg")
+	}
+	return strings.HasSuffix(email, "@schools.gov.sg") || strings.HasSuffix(email, "@tech.gov.sg")
+}
+
+func isValidEmailFormat(email string) bool {
+	email = strings.TrimSpace(email)
+	if len(email) < 5 || len(email) > 254 {
+		return false
+	}
+	return strings.Contains(email, "@")
+}
+
+// ------------------------------------------- REQUEST OTP -------------------------------------------
+func (h *Handler) Request(w http.ResponseWriter, r *http.Request) {
+	logger := middleware.LoggerFromContext(r.Context())
+
+	ct := r.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/json") {
+		writeErrorResponse(w, http.StatusUnsupportedMediaType, ErrorCodeInvalidForm, "Content-Type must be application/json")
+		logger.Error("Content-Type must be application/json", "content_type", ct)
+		return
+	}
+
+	var body requestOTPRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeErrorResponse(w, http.StatusBadRequest, ErrorCodeInvalidForm, "One or more input has an error")
+		logger.Error("email not found in request body", "err", err)
+		return
+	}
+
+	body.Email = strings.TrimSpace(body.Email)
+	if body.Email == "" {
+		writeErrorResponse(w, http.StatusUnprocessableEntity, ErrorCodeInvalidForm, "One or more input has an error")
+		logger.Error("email required in request body")
+		return
+	}
+
+	if !isValidEmailFormat(body.Email) {
+		writeErrorResponse(w, http.StatusUnprocessableEntity, ErrorCodeInvalidForm, "One or more input has an error")
+		logger.Error("email not a valid email format")
+		return
+	}
+
+	if !isAllowedEmail(body.Email, h.cfg.Environment) {
+		writeErrorResponse(w, http.StatusUnprocessableEntity, ErrorCodeInvalidForm, "One or more input has an error")
+		logger.Error("email not a valid schools.gov.sg email")
+		return
+	}
+
+	payload, err := json.Marshal(map[string]string{"email": body.Email})
+	if err != nil {
+		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Internal server error")
+		logger.Error("failed to marshal request body", "err", err)
+		return
+	}
+
+	req, err := http.NewRequest(http.MethodPost, h.cfg.OTPaaS.Host+"/otp", bytes.NewReader(payload))
+	if err != nil {
+		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Internal server error")
+		logger.Error("failed to create request", "err", err)
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+buildAuthToken(h.cfg.OTPaaS.AppID, h.cfg.OTPaaS.Namespace, h.cfg.OTPaaS.Secret))
+	req.Header.Set("X-App-Id", h.cfg.OTPaaS.AppID)
+	req.Header.Set("X-App-Namespace", h.cfg.OTPaaS.Namespace)
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			writeErrorResponse(w, http.StatusGatewayTimeout, ErrorCodeRequestTimeout, "Request timeout. Please try again later.")
+			logger.Error("OTPaas request timeout", "err", err)
+			return
+		}
+		writeErrorResponse(w, http.StatusBadGateway, ErrorCodeInternalServerError, "Internal server error")
+		logger.Error("error sending request to OTPaas", "err", err)
+		return
+	}
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		writeErrorResponse(w, http.StatusTooManyRequests, ErrorCodeInternalServerError, "OTPaas rate limited")
+		logger.Error("otpaas rate limited", "otpaas_status_code", resp.StatusCode)
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Internal server error")
+		logger.Error("authorization failed", "otpaas_status_code", resp.StatusCode)
+		return
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Error("failed to close response body", "err", err)
+		}
+	}()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Internal server error")
+		logger.Error("failed to read response body", "err", err, "otpaas_status_code", resp.StatusCode)
+		return
+	}
+
+	var otpResp requestOTPResponse
+	if err := json.Unmarshal(bodyBytes, &otpResp); err != nil {
+		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Invalid OTPaas response")
+		logger.Error("failed to unmarshal response body", "err", err, "otpaas_status_code", resp.StatusCode)
+		return
+	}
+
+	if otpResp.ID == "" {
+		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Missing id from OTPaas")
+		logger.Error("failed to get id from OTPaas", "otpaas_status_code", resp.StatusCode)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(map[string]string{"flow_id": otpResp.ID}); err != nil {
+		logger.Error("failed to encode response", "err", err)
+	}
+}
+
+// ------------------------------------------- VERIFY OTP -------------------------------------------
+
+type verifyOTPRequest struct {
+	PIN string `json:"pin"`
+}
+
+func (h *Handler) Verify(w http.ResponseWriter, r *http.Request) {
+	logger := middleware.LoggerFromContext(r.Context())
+
+	flowID := r.PathValue("flow_id")
+	if flowID == "" {
+		writeErrorResponse(w, http.StatusBadRequest, ErrorCodeInvalidForm, "One or more input has an error")
+		logger.Error("flow_id is required")
+		return
+	}
+
+	ct := r.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/json") {
+		writeErrorResponse(w, http.StatusUnsupportedMediaType, ErrorCodeInvalidForm, "Content-Type must be application/json")
+		logger.Error("Content-Type must be application/json", "content_type", ct)
+		return
+	}
+
+	var body verifyOTPRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeErrorResponse(w, http.StatusBadRequest, ErrorCodeInvalidForm, "One or more input has an error")
+		logger.Error("pin not found in request body", "err", err)
+		return
+	}
+
+	if body.PIN == "" {
+		writeErrorResponse(w, http.StatusUnprocessableEntity, ErrorCodeInvalidForm, "One or more input has an error")
+		logger.Error("pin is required")
+		return
+	}
+	if len(body.PIN) != 6 {
+		writeErrorResponse(w, http.StatusUnprocessableEntity, ErrorCodeInvalidForm, "One or more input has an error")
+		logger.Error("pin is not a valid 6 digit PIN")
+		return
+	}
+
+	payload, err := json.Marshal(map[string]string{"pin": body.PIN})
+	if err != nil {
+		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Internal server error")
+		logger.Error("failed to marshal request body", "err", err)
+		return
+	}
+
+	req, err := http.NewRequest("PUT", h.cfg.OTPaaS.Host+"/otp/"+flowID, bytes.NewReader(payload))
+	if err != nil {
+		writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Internal server error")
+		logger.Error("failed to create request", "err", err)
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+buildAuthToken(h.cfg.OTPaaS.AppID, h.cfg.OTPaaS.Namespace, h.cfg.OTPaaS.Secret))
+	req.Header.Set("X-App-Id", h.cfg.OTPaaS.AppID)
+	req.Header.Set("X-App-Namespace", h.cfg.OTPaaS.Namespace)
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			writeErrorResponse(w, http.StatusGatewayTimeout, ErrorCodeRequestTimeout, "Request timeout. Please try again later.")
+			logger.Error("OTPaas request timeout", "err", err)
+			return
+		}
+		writeErrorResponse(w, http.StatusBadGateway, ErrorCodeInternalServerError, "Internal server error")
+		logger.Error("error sending request to OTPaas", "err", err)
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		switch resp.StatusCode {
+		case http.StatusUnauthorized:
+			writeErrorResponse(w, http.StatusUnprocessableEntity, ErrorCodeAuth, "Failed to authenticate session.")
+			logger.Error("invalid PIN", "otpaas_status_code", resp.StatusCode)
+			return
+		case http.StatusNotFound:
+			writeErrorResponse(w, http.StatusNotFound, ErrorCodeAuth, "Failed to authenticate session.")
+			logger.Error("pin expired", "otpaas_status_code", resp.StatusCode)
+			return
+		case http.StatusTooManyRequests:
+			writeErrorResponse(w, http.StatusTooManyRequests, ErrorCodeAuth, "Too many verification attempts.")
+			logger.Error("OTPaas rate limited", "otpaas_status_code", resp.StatusCode)
+			return
+		default:
+			writeErrorResponse(w, http.StatusInternalServerError, ErrorCodeInternalServerError, "Internal server error")
+			logger.Error("internal server error", "otpaas_status_code", resp.StatusCode)
+			return
+		}
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Error("failed to close response body", "err", err)
+		}
+	}()
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server/cmd/otp/otp_test.go
+++ b/server/cmd/otp/otp_test.go
@@ -19,7 +19,7 @@ func (f RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 
 // -------------------- handler tests: Request --------------------
 
-func TestRequest_Success200(t *testing.T) {
+func TestHandlerRequest_Success200(t *testing.T) {
 	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
@@ -46,7 +46,7 @@ func TestRequest_Success200(t *testing.T) {
 	require.Equal(t, "123", payload["flow_id"])
 }
 
-func TestRequest_UnsupportedMediaType415(t *testing.T) {
+func TestHandlerRequest_UnsupportedMediaType415(t *testing.T) {
 	h := &Handler{cfg: Default(), client: &http.Client{}}
 
 	req := httptest.NewRequest(http.MethodPost, "/request", nil)
@@ -58,13 +58,12 @@ func TestRequest_UnsupportedMediaType415(t *testing.T) {
 	res := rec.Result()
 	require.Equal(t, http.StatusUnsupportedMediaType, res.StatusCode)
 
-	var errResp errorResponse
+	var errResp ErrorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
-	require.Equal(t, ErrorCodeInvalidForm, errResp.Code)
-	require.Equal(t, "Content-Type must be application/json", errResp.Message)
+	require.Equal(t, http.StatusText(http.StatusUnsupportedMediaType), errResp.Message)
 }
 
-func TestRequest_InvalidEmailDomain422(t *testing.T) {
+func TestHandlerRequest_InvalidEmailDomain422(t *testing.T) {
 	h := &Handler{cfg: Default(), client: &http.Client{}}
 
 	body, _ := json.Marshal(map[string]string{"email": "test@example.com"})
@@ -78,13 +77,12 @@ func TestRequest_InvalidEmailDomain422(t *testing.T) {
 	res := rec.Result()
 	require.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
 
-	var errResp errorResponse
+	var errResp ErrorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
-	require.Equal(t, ErrorCodeInvalidForm, errResp.Code)
 	require.Equal(t, "One or more input has an error", errResp.Message)
 }
 
-func TestRequest_InvalidEmailDomainProduction422(t *testing.T) {
+func TestHandlerRequest_InvalidEmailDomainProduction422(t *testing.T) {
 	cfg := Default()
 	cfg.Environment = EnvProduction
 	h := &Handler{cfg: cfg, client: &http.Client{}}
@@ -100,17 +98,16 @@ func TestRequest_InvalidEmailDomainProduction422(t *testing.T) {
 	res := rec.Result()
 	require.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
 
-	var errResp errorResponse
+	var errResp ErrorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
-	require.Equal(t, ErrorCodeInvalidForm, errResp.Code)
 	require.Equal(t, "One or more input has an error", errResp.Message)
 }
 
-func TestRequest_OTPaasRateLimited429(t *testing.T) {
+func TestHandlerRequest_OTPaasRateLimited429(t *testing.T) {
 	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
-			StatusCode: http.StatusTooManyRequests,
-			Body:       io.NopCloser(bytes.NewReader([]byte(`{}`))),
+			StatusCode: http.StatusBadRequest,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{"code":2008,"message":"rate limited"}`))),
 		}, nil
 	})
 
@@ -127,13 +124,12 @@ func TestRequest_OTPaasRateLimited429(t *testing.T) {
 	res := rec.Result()
 	require.Equal(t, http.StatusTooManyRequests, res.StatusCode)
 
-	var errResp errorResponse
+	var errResp ErrorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
-	require.Equal(t, ErrorCodeInternalServerError, errResp.Code)
-	require.Equal(t, "OTPaas rate limited", errResp.Message)
+	require.Equal(t, "Too many requests. Please try again later.", errResp.Message)
 }
 
-func TestRequest_OTPaasInternal500(t *testing.T) {
+func TestHandlerRequest_OTPaasInternal500(t *testing.T) {
 	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusInternalServerError,
@@ -154,15 +150,14 @@ func TestRequest_OTPaasInternal500(t *testing.T) {
 	res := rec.Result()
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
 
-	var errResp errorResponse
+	var errResp ErrorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
-	require.Equal(t, ErrorCodeInternalServerError, errResp.Code)
-	require.Equal(t, "Internal server error", errResp.Message)
+	require.Equal(t, `Unexpected status 500 (code 0): ""`, errResp.Message)
 }
 
 // -------------------- handler tests: Verify --------------------
 
-func TestVerify_Success204(t *testing.T) {
+func TestHandlerVerify_Success204(t *testing.T) {
 	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
@@ -185,7 +180,7 @@ func TestVerify_Success204(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, res.StatusCode)
 }
 
-func TestVerify_UnsupportedMediaType415(t *testing.T) {
+func TestHandlerVerify_UnsupportedMediaType415(t *testing.T) {
 	h := &Handler{cfg: Default(), client: &http.Client{}}
 
 	body, _ := json.Marshal(map[string]string{"pin": "123456"})
@@ -199,31 +194,47 @@ func TestVerify_UnsupportedMediaType415(t *testing.T) {
 	res := rec.Result()
 	require.Equal(t, http.StatusUnsupportedMediaType, res.StatusCode)
 
-	var errResp errorResponse
+	var errResp ErrorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
-	require.Equal(t, ErrorCodeInvalidForm, errResp.Code)
 }
 
-func TestVerify_InvalidPin422(t *testing.T) {
+func TestHandlerVerify_InvalidPin422(t *testing.T) {
 	h := &Handler{cfg: Default(), client: &http.Client{}}
 
-	body, _ := json.Marshal(map[string]string{"pin": "123"})
-	req := httptest.NewRequest(http.MethodPost, "/verify/flow123", bytes.NewReader(body))
-	req.SetPathValue("flow_id", "flow123")
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "empty pin",
+			body: []byte(`{"pin":""}`),
+		},
+		{
+			name: "pin longer than 6 digits",
+			body: []byte(`{"pin":"1234567"}`),
+		},
+	}
 
-	h.Verify(rec, req)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/verify/flow123", bytes.NewReader(tt.body))
+			req.SetPathValue("flow_id", "flow123")
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
 
-	res := rec.Result()
-	require.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
+			h.Verify(rec, req)
 
-	var errResp errorResponse
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
-	require.Equal(t, ErrorCodeInvalidForm, errResp.Code)
+			res := rec.Result()
+			require.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
+
+			var errResp ErrorResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+			require.Equal(t, "One or more input has an error", errResp.Message)
+		})
+	}
 }
 
-func TestVerify_NotFound404(t *testing.T) {
+func TestHandlerVerify_NotFound404(t *testing.T) {
 	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusNotFound,
@@ -245,13 +256,12 @@ func TestVerify_NotFound404(t *testing.T) {
 	res := rec.Result()
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
 
-	var errResp errorResponse
+	var errResp ErrorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
-	require.Equal(t, ErrorCodeAuth, errResp.Code)
-	require.Equal(t, "Failed to authenticate session.", errResp.Message)
+	require.Equal(t, "Flow expired", errResp.Message)
 }
 
-func TestVerify_OTPaasInternal500(t *testing.T) {
+func TestHandlerVerify_OTPaasInternal500(t *testing.T) {
 	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusInternalServerError,
@@ -273,8 +283,7 @@ func TestVerify_OTPaasInternal500(t *testing.T) {
 	res := rec.Result()
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
 
-	var errResp errorResponse
+	var errResp ErrorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
-	require.Equal(t, ErrorCodeInternalServerError, errResp.Code)
-	require.Equal(t, "Internal server error", errResp.Message)
+	require.Equal(t, `Unexpected status 500 (code 0): ""`, errResp.Message)
 }

--- a/server/cmd/otp/otp_test.go
+++ b/server/cmd/otp/otp_test.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/String-sg/teacher-workspace/server/pkg/require"
+)
+
+type RoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+// -------------------- handler tests: Request --------------------
+
+func TestRequest_Success200(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{"id":"123"}`))),
+		}, nil
+	})
+
+	cfg := Default()
+	h := &Handler{cfg: cfg, client: &http.Client{Transport: rt, Timeout: cfg.OTPaaS.Timeout}}
+
+	body, _ := json.Marshal(map[string]string{"email": "test@schools.gov.sg"})
+	req := httptest.NewRequest(http.MethodPost, "/request", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.Request(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, "application/json", res.Header.Get("Content-Type"))
+
+	var payload map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+	require.Equal(t, "123", payload["flow_id"])
+}
+
+func TestRequest_UnsupportedMediaType415(t *testing.T) {
+	h := &Handler{cfg: Default(), client: &http.Client{}}
+
+	req := httptest.NewRequest(http.MethodPost, "/request", nil)
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+
+	h.Request(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusUnsupportedMediaType, res.StatusCode)
+
+	var errResp errorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	require.Equal(t, ErrorCodeInvalidForm, errResp.Code)
+	require.Equal(t, "Content-Type must be application/json", errResp.Message)
+}
+
+func TestRequest_InvalidEmailDomain422(t *testing.T) {
+	h := &Handler{cfg: Default(), client: &http.Client{}}
+
+	body, _ := json.Marshal(map[string]string{"email": "test@example.com"})
+
+	req := httptest.NewRequest(http.MethodPost, "/request", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.Request(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
+
+	var errResp errorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	require.Equal(t, ErrorCodeInvalidForm, errResp.Code)
+	require.Equal(t, "One or more input has an error", errResp.Message)
+}
+
+func TestRequest_InvalidEmailDomainProduction422(t *testing.T) {
+	cfg := Default()
+	cfg.Environment = EnvProduction
+	h := &Handler{cfg: cfg, client: &http.Client{}}
+
+	body, _ := json.Marshal(map[string]string{"email": "test@tech.gov.sg"})
+
+	req := httptest.NewRequest(http.MethodPost, "/request", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.Request(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
+
+	var errResp errorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	require.Equal(t, ErrorCodeInvalidForm, errResp.Code)
+	require.Equal(t, "One or more input has an error", errResp.Message)
+}
+
+func TestRequest_OTPaasRateLimited429(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{}`))),
+		}, nil
+	})
+
+	cfg := Default()
+	h := &Handler{cfg: cfg, client: &http.Client{Transport: rt, Timeout: cfg.OTPaaS.Timeout}}
+
+	body, _ := json.Marshal(map[string]string{"email": "test@schools.gov.sg"})
+	req := httptest.NewRequest(http.MethodPost, "/request", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.Request(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusTooManyRequests, res.StatusCode)
+
+	var errResp errorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	require.Equal(t, ErrorCodeInternalServerError, errResp.Code)
+	require.Equal(t, "OTPaas rate limited", errResp.Message)
+}
+
+func TestRequest_OTPaasInternal500(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{}`))),
+		}, nil
+	})
+
+	cfg := Default()
+	h := &Handler{cfg: cfg, client: &http.Client{Transport: rt, Timeout: cfg.OTPaaS.Timeout}}
+
+	body, _ := json.Marshal(map[string]string{"email": "test@schools.gov.sg"})
+	req := httptest.NewRequest(http.MethodPost, "/request", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.Request(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+
+	var errResp errorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	require.Equal(t, ErrorCodeInternalServerError, errResp.Code)
+	require.Equal(t, "Internal server error", errResp.Message)
+}
+
+// -------------------- handler tests: Verify --------------------
+
+func TestVerify_Success204(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{}`))),
+		}, nil
+	})
+
+	cfg := Default()
+	h := &Handler{cfg: cfg, client: &http.Client{Transport: rt, Timeout: cfg.OTPaaS.Timeout}}
+
+	body, _ := json.Marshal(map[string]string{"pin": "123456"})
+	req := httptest.NewRequest(http.MethodPost, "/verify/flow123", bytes.NewReader(body))
+	req.SetPathValue("flow_id", "flow123")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.Verify(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusNoContent, res.StatusCode)
+}
+
+func TestVerify_UnsupportedMediaType415(t *testing.T) {
+	h := &Handler{cfg: Default(), client: &http.Client{}}
+
+	body, _ := json.Marshal(map[string]string{"pin": "123456"})
+	req := httptest.NewRequest(http.MethodPost, "/verify/flow123", bytes.NewReader(body))
+	req.SetPathValue("flow_id", "flow123")
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+
+	h.Verify(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusUnsupportedMediaType, res.StatusCode)
+
+	var errResp errorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	require.Equal(t, ErrorCodeInvalidForm, errResp.Code)
+}
+
+func TestVerify_InvalidPin422(t *testing.T) {
+	h := &Handler{cfg: Default(), client: &http.Client{}}
+
+	body, _ := json.Marshal(map[string]string{"pin": "123"})
+	req := httptest.NewRequest(http.MethodPost, "/verify/flow123", bytes.NewReader(body))
+	req.SetPathValue("flow_id", "flow123")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.Verify(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
+
+	var errResp errorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	require.Equal(t, ErrorCodeInvalidForm, errResp.Code)
+}
+
+func TestVerify_NotFound404(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{}`))),
+		}, nil
+	})
+
+	cfg := Default()
+	h := &Handler{cfg: cfg, client: &http.Client{Transport: rt, Timeout: cfg.OTPaaS.Timeout}}
+
+	body, _ := json.Marshal(map[string]string{"pin": "123456"})
+	req := httptest.NewRequest(http.MethodPost, "/verify/flow123", bytes.NewReader(body))
+	req.SetPathValue("flow_id", "flow123")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.Verify(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusNotFound, res.StatusCode)
+
+	var errResp errorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	require.Equal(t, ErrorCodeAuth, errResp.Code)
+	require.Equal(t, "Failed to authenticate session.", errResp.Message)
+}
+
+func TestVerify_OTPaasInternal500(t *testing.T) {
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{}`))),
+		}, nil
+	})
+
+	cfg := Default()
+	h := &Handler{cfg: cfg, client: &http.Client{Transport: rt, Timeout: cfg.OTPaaS.Timeout}}
+
+	body, _ := json.Marshal(map[string]string{"pin": "123456"})
+	req := httptest.NewRequest(http.MethodPost, "/verify/flow123", bytes.NewReader(body))
+	req.SetPathValue("flow_id", "flow123")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.Verify(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+
+	var errResp errorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	require.Equal(t, ErrorCodeInternalServerError, errResp.Code)
+	require.Equal(t, "Internal server error", errResp.Message)
+}


### PR DESCRIPTION
## 🚀 Summary

Built a standalone OTP service in server/cmd/otp that fronts OTPaaS. It starts its own HTTP server, loads/validates env config, returns consistent JSON errors, and includes unit tests for the main success/error paths.

## ✏️ Changes

- Added POST /request and POST /verify/{flow_id} endpoints backed by OTPaaS.
- Added input validation (Content-Type, email/pin checks) and clear status/error mapping (415/422/404/429/500).
- Wired request-scoped logging middleware plus server timeouts and graceful shutdown.
- Added unit tests covering key response codes and mappings.