### PR TITLE
feat: add help to sidebar

### DIFF
--- a/web/components/Sidebar/Sidebar.tsx
+++ b/web/components/Sidebar/Sidebar.tsx
@@ -36,7 +36,7 @@ const Sidebar: React.FC<SidebarProps> = ({ className, children, ...props }) => {
   return (
     <nav
       className={cn(
-        'ease-tw-default relative hidden w-16 bg-slate-2 inset-shadow-[0_0_0_1px] inset-shadow-slate-5 transition-[width] sm:block',
+        'ease-tw-default relative hidden w-16 bg-slate-2 inset-shadow-[0_0_0_1px] inset-shadow-slate-5 transition-[width] sm:flex sm:flex-col',
         isOpen && 'w-60',
         className,
       )}

--- a/web/components/Sidebar/SidebarContent.tsx
+++ b/web/components/Sidebar/SidebarContent.tsx
@@ -5,7 +5,7 @@ export type SidebarContentProps = React.ComponentPropsWithoutRef<'div'>;
 
 const SidebarContent: React.FC<SidebarContentProps> = ({ children, className, ...props }) => {
   return (
-    <div className={cn('flex flex-col gap-y-xs px-sm', className)} {...props}>
+    <div className={cn('flex flex-1 flex-col gap-y-xs px-sm', className)} {...props}>
       {children}
     </div>
   );

--- a/web/components/Sidebar/SidebarFooter.tsx
+++ b/web/components/Sidebar/SidebarFooter.tsx
@@ -1,0 +1,14 @@
+import { cn } from '@flow/core';
+import React from 'react';
+
+export type SidebarFooterProps = React.ComponentPropsWithoutRef<'div'>;
+
+const SidebarFooter: React.FC<SidebarFooterProps> = ({ children, className, ...props }) => {
+  return (
+    <div className={cn('flex flex-col gap-y-sm px-sm pb-sm', className)} {...props}>
+      {children}
+    </div>
+  );
+};
+
+export default SidebarFooter;

--- a/web/containers/RootLayout.tsx
+++ b/web/containers/RootLayout.tsx
@@ -1,5 +1,5 @@
 import { cn, TooltipProvider } from '@flow/core';
-import { Home, UsersRound } from '@flow/icons';
+import { HelpCircle, Home, UsersRound } from '@flow/icons';
 import React, { useMemo, useRef } from 'react';
 import { Outlet, useLocation } from 'react-router';
 
@@ -33,23 +33,34 @@ const RootLayout: React.FC = () => {
     <TooltipProvider delayDuration={600}>
       <div className="flex h-svh">
         <SidebarProvider>
-          <Sidebar>
+          <Sidebar className="sm:flex sm:flex-col">
             <SidebarHeader />
 
-            <SidebarContent>
+            <div className="flex-1">
+              <SidebarContent>
+                <SidebarItem
+                  icon={Home}
+                  label="Home"
+                  tooltip="Home"
+                  to="/"
+                  selected={selected === '/'}
+                />
+                <SidebarItem
+                  icon={UsersRound}
+                  label="Students"
+                  tooltip="Students"
+                  to="/students"
+                  selected={selected === 'students'}
+                />
+              </SidebarContent>
+            </div>
+
+            <SidebarContent className="py-sm">
               <SidebarItem
-                icon={Home}
-                label="Home"
-                tooltip="Home"
-                to="/"
-                selected={selected === '/'}
-              />
-              <SidebarItem
-                icon={UsersRound}
-                label="Students"
-                tooltip="Students"
-                to="/students"
-                selected={selected === 'students'}
+                icon={HelpCircle}
+                label="Help"
+                tooltip="Help"
+                href="https://transform.gov.sg/"
               />
             </SidebarContent>
           </Sidebar>

--- a/web/containers/RootLayout.tsx
+++ b/web/containers/RootLayout.tsx
@@ -11,6 +11,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from '~/components/Sidebar';
+import SidebarFooter from '~/components/Sidebar/SidebarFooter';
 import { useIsWithinViewport } from '~/hooks/useIsWithinViewport';
 
 const RootLayout: React.FC = () => {
@@ -33,36 +34,34 @@ const RootLayout: React.FC = () => {
     <TooltipProvider delayDuration={600}>
       <div className="flex h-svh">
         <SidebarProvider>
-          <Sidebar className="sm:flex sm:flex-col">
+          <Sidebar>
             <SidebarHeader />
 
-            <div className="flex-1">
-              <SidebarContent>
-                <SidebarItem
-                  icon={Home}
-                  label="Home"
-                  tooltip="Home"
-                  to="/"
-                  selected={selected === '/'}
-                />
-                <SidebarItem
-                  icon={UsersRound}
-                  label="Students"
-                  tooltip="Students"
-                  to="/students"
-                  selected={selected === 'students'}
-                />
-              </SidebarContent>
-            </div>
+            <SidebarContent className="flex-1">
+              <SidebarItem
+                icon={Home}
+                label="Home"
+                tooltip="Home"
+                to="/"
+                selected={selected === '/'}
+              />
+              <SidebarItem
+                icon={UsersRound}
+                label="Students"
+                tooltip="Students"
+                to="/students"
+                selected={selected === 'students'}
+              />
+            </SidebarContent>
 
-            <SidebarContent className="py-sm">
+            <SidebarFooter>
               <SidebarItem
                 icon={HelpCircle}
                 label="Help"
                 tooltip="Help"
                 href="https://transform.gov.sg/"
               />
-            </SidebarContent>
+            </SidebarFooter>
           </Sidebar>
 
           <div className="relative flex-1 overflow-y-auto">

--- a/web/containers/RootLayout.tsx
+++ b/web/containers/RootLayout.tsx
@@ -37,7 +37,7 @@ const RootLayout: React.FC = () => {
           <Sidebar>
             <SidebarHeader />
 
-            <SidebarContent className="flex-1">
+            <SidebarContent>
               <SidebarItem
                 icon={Home}
                 label="Home"


### PR DESCRIPTION
## 🚀 Summary

Added a bottom-pinned Help item to the sidebar.

## ✏️ Changes

- Updated RootLayout to restructure the sidebar into a flex column (SidebarHeader + growable main content + fixed footer)
- Wrapped the main navigation SidebarContent in a flex-1 container so it grows and leaves space for a footer
- Added a bottom SidebarContent section containing a SidebarItem “Help” entry that links to https://transform.gov.sg/ (interim)