### PR TITLE
feat: log config validation errors as a flat slice of strings

### DIFF
--- a/server/cmd/tw/main.go
+++ b/server/cmd/tw/main.go
@@ -42,7 +42,7 @@ func main() {
 		os.Exit(1)
 	}
 	if err := cfg.Validate(); err != nil {
-		slog.Error("invalid configuration", "err", err)
+		slog.Error("invalid configuration", "errs", collectErrorMessages(err))
 		os.Exit(1)
 	}
 
@@ -128,4 +128,22 @@ func run(ctx context.Context, cfg *config.Config) error {
 	}
 
 	return nil
+}
+
+// collectErrorMessages recursively unwraps joined errors and returns their
+// leaf error messages as a flat slice of strings.
+func collectErrorMessages(err error) []string {
+	if err == nil {
+		return nil
+	}
+
+	if werr, ok := err.(interface{ Unwrap() []error }); ok {
+		var msgs []string
+		for _, cerr := range werr.Unwrap() {
+			msgs = append(msgs, collectErrorMessages(cerr)...)
+		}
+		return msgs
+	}
+
+	return []string{err.Error()}
 }


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR improves configuration validation error logging by flattening nested and joined errors into a slice of error messages.

Below is a comparison of the invalid configuration log output before and after this change.

Before:
```json
{"time":"2026-03-15T05:33:19+08:00","level":"ERROR","msg":"invalid configuration","err":"TW_OTPAAS_ID is required\nTW_OTPAAS_NAMESPACE is required\nTW_OTPAAS_SECRET is required"}
```

After:
```json
{"time":"2026-03-15T05:32:40+08:00","level":"ERROR","msg":"invalid configuration","errs":["TW_OTPAAS_ID is required","TW_OTPAAS_NAMESPACE is required","TW_OTPAAS_SECRET is required"]}
```

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Added `collectErrorMessages` to recursively collect validation errors from joined errors
- Updated invalid configuration logging to use the new `collectErrorMessages`