### PR TITLE
chore: ignore `build` and `dist` directories in lint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,5 @@
 import js from '@eslint/js';
-import { defineConfig } from 'eslint/config';
+import { defineConfig, globalIgnores } from 'eslint/config';
 import pluginReact from 'eslint-plugin-react';
 import pluginReactHooks from 'eslint-plugin-react-hooks';
 import pluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
@@ -7,6 +7,8 @@ import globals from 'globals';
 import ts from 'typescript-eslint';
 
 export default defineConfig([
+  globalIgnores(['**/build/**', '**/dist/**']),
+
   {
     files: ['**/*.{js,jsx,ts,tsx}'],
     languageOptions: { globals: globals.browser },


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR ignores `build` and `dist` in lint config. These directories contain generated artefacts and should not be checked by the linter.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Updated lint config to ignore `build` and `dist` directories