### PR TITLE
fix(web): fix sidebar design mismatch

### DIFF
--- a/web/components/Sidebar/Sidebar.tsx
+++ b/web/components/Sidebar/Sidebar.tsx
@@ -13,7 +13,7 @@ const Sidebar: React.FC<SidebarProps> = ({ className, children, ...props }) => {
       <>
         <nav
           className={cn(
-            'fixed inset-y-0 left-0 z-1001 w-60 -translate-x-full bg-slate-2 inset-shadow-[0_0_0_1px] inset-shadow-slate-5 transition-transform sm:hidden',
+            'fixed inset-y-0 left-0 z-1001 flex w-60 -translate-x-full flex-col bg-slate-2 inset-shadow-[0_0_0_1px] inset-shadow-slate-5 transition-transform sm:hidden',
             isMobileOpen && 'translate-x-0',
             className,
           )}

--- a/web/components/Sidebar/SidebarHeader.tsx
+++ b/web/components/Sidebar/SidebarHeader.tsx
@@ -8,9 +8,9 @@ import SidebarTrigger from './SidebarTrigger';
 export type SidebarHeaderProps = React.ComponentPropsWithoutRef<'div'>;
 
 const SidebarHeader: React.FC<SidebarHeaderProps> = ({ className, ...props }) => {
-  const { isOpen, isMobileOpen } = useSidebarContext();
+  const { isOpen, isMobileOpen, isMobile } = useSidebarContext();
 
-  const isExpanded = isOpen || isMobileOpen;
+  const isExpanded = isOpen || (isMobile && isMobileOpen);
 
   return (
     <div className={cn('relative flex items-center justify-end p-sm', className)} {...props}>

--- a/web/components/Sidebar/SidebarItem.tsx
+++ b/web/components/Sidebar/SidebarItem.tsx
@@ -74,14 +74,15 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
   selected,
   ...props
 }) => {
-  const { isOpen, isMobileOpen } = useSidebarContext();
+  const { isOpen, isMobileOpen, isMobile } = useSidebarContext();
 
-  // A workaround to prevent the tooltip from being shown when the sidebar is open.
+  const isExpanded = isOpen || (isMobile && isMobileOpen);
+
   const handlePointerMove = <T extends HTMLElement>(
     event: React.PointerEvent<T>,
     handler?: React.PointerEventHandler<T>,
   ) => {
-    if (isOpen) {
+    if (isExpanded) {
       event.preventDefault();
       return;
     }
@@ -100,7 +101,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
       <Icon className="flex h-4 w-4 shrink-0 text-slate-11" />
 
       <AnimatePresence initial={false}>
-        {(isOpen || isMobileOpen) && (
+        {isExpanded && (
           <Typography asChild variant="label-md" className="text-slate-12">
             <motion.p
               initial={{ opacity: 0, x: -16 }}
@@ -127,6 +128,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
 
   if ('href' in props && props.href !== undefined) {
     const { onPointerMove, ...anchorProps } = props;
+
     return (
       <Tooltip classNames={{ content: 'bg-slate-12 z-10000' }}>
         <TooltipTrigger asChild>
@@ -149,6 +151,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
 
   if ('to' in props && props.to !== undefined) {
     const { onPointerMove, ...linkProps } = props;
+
     return (
       <Tooltip classNames={{ content: 'bg-slate-12 z-10000' }}>
         <TooltipTrigger asChild>
@@ -168,6 +171,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
   }
 
   const { onPointerMove, ...buttonProps } = props;
+
   return (
     <Tooltip classNames={{ content: 'bg-slate-12 z-10000' }}>
       <TooltipTrigger asChild>

--- a/web/containers/RootLayout.tsx
+++ b/web/containers/RootLayout.tsx
@@ -71,12 +71,12 @@ const RootLayout: React.FC = () => {
                   'ease-tw-default absolute inset-x-0 top-full h-px bg-transparent transition-colors duration-300',
                   !isWithinViewport && 'bg-slate-12/7.5',
                 )}
-              ></div>
+              />
 
               <SidebarTrigger />
             </div>
 
-            <div ref={topbarRef} className="absolute inset-x-0 top-0 h-px"></div>
+            <div ref={topbarRef} className="absolute inset-x-0 top-0 h-px" />
 
             <Outlet />
           </div>


### PR DESCRIPTION
closes #96 

## 🚀 Summary

Fix issues raised in #96 

## ✏️ Changes

1. Add `flex` to mobile sidebar for 'Help' to stick to the bottom
2. Stricter checks for expanded sidebar to ensure labels are not visible, when moving between responsive states 
3. ~~Add `isExpanded` to `SidebarProvider`~~
