### PR TITLE
chore: bump Go version from `1.25.6` to `1.26.1`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/String-sg/teacher-workspace
 
-go 1.25.6
+go 1.26.1
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.5.0


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR bumps Go version from `1.25.6` to `1.26.1`.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Bumped Go version from `1.25.6` to `1.26.1`