### PR TITLE
chore: enable `gofmt` and `goimports` check through `golangci-lint`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,11 @@
+version: '2'
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR enables `gofmt` and `goimports` checks through `golangci-lint` to enforce consistent formatting and import ordering in CI.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Enabled `gofmt` checks in `golangci-lint`
- Enabled `goimports` checks in `golangci-lint`