### PR TITLE
chore: scope VS Code default formatter per language

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,8 @@
   },
   "[yaml]": {
     "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[go]": {
+    "editor.defaultFormatter": "golang.go"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "editor.defaultFormatter": "oxc.oxc-vscode",
   "[javascript]": {
     "editor.defaultFormatter": "oxc.oxc-vscode"
   },


### PR DESCRIPTION
## 🚀 Summary

The top-level `editor.defaultFormatter` in `.vscode/settings.json` was applying `oxc` as the default for every file type, including Go, where it should not be used. This PR removes the global default and adds a `[go]` block so Go files are formatted by the official Go extension.

## ✏️ Changes

- Removed top-level `editor.defaultFormatter` in `.vscode/settings.json`
- Added `[go]` language block in `.vscode/settings.json` pointing to `golang.go`