### PR TITLE
fix(`dotenv`): decode string into prepopulated `*url.URL` field

### DIFF
--- a/server/pkg/dotenv/dotenv.go
+++ b/server/pkg/dotenv/dotenv.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -56,7 +57,7 @@ func decode(data []byte, output any) error {
 		WeaklyTypedInput: true,
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			mapstructure.StringToTimeDurationHookFunc(),
-			mapstructure.StringToURLHookFunc(),
+			stringToURLFunc(),
 			stringToLogLevelFunc(),
 		),
 	})
@@ -84,6 +85,30 @@ func environToMap(environ []string) map[string]string {
 	}
 
 	return m
+}
+
+// stringToURLFunc converts a string to a *url.URL or url.URL. The built-in
+// StringToURLHookFunc only targets *url.URL, which fails when the destination
+// pointer is already populated because mapstructure dereferences it and passes
+// url.URL as the target type.
+func stringToURLFunc() mapstructure.DecodeHookFunc {
+	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		switch t {
+		case reflect.TypeFor[*url.URL]():
+			return url.Parse(data.(string))
+		case reflect.TypeFor[url.URL]():
+			u, err := url.Parse(data.(string))
+			if err != nil {
+				return nil, err
+			}
+			return *u, nil
+		default:
+			return data, nil
+		}
+	}
 }
 
 // stringToLogLevelFunc converts a string to a slog.Level.

--- a/server/pkg/dotenv/dotenv_test.go
+++ b/server/pkg/dotenv/dotenv_test.go
@@ -201,9 +201,10 @@ func TestDecode(t *testing.T) {
 		}
 
 		tests := []struct {
-			name  string
-			value string
-			want  string
+			name    string
+			initial *url.URL
+			value   string
+			want    string
 		}{
 			{
 				name:  "http",
@@ -220,6 +221,15 @@ func TestDecode(t *testing.T) {
 				value: "",
 				want:  "",
 			},
+			{
+				name: "overrides prepopulated pointer",
+				initial: func() *url.URL {
+					u, _ := url.Parse("http://default:1234")
+					return u
+				}(),
+				value: "http://override:5678",
+				want:  "http://override:5678",
+			},
 		}
 
 		for _, test := range tests {
@@ -228,7 +238,7 @@ func TestDecode(t *testing.T) {
 					"TEST_BASE_URL=" + test.value,
 				}, "\n")
 
-				var cfg TestConfig
+				cfg := TestConfig{BaseURL: test.initial}
 				err := decode([]byte(content), &cfg)
 
 				t.Cleanup(func() {


### PR DESCRIPTION
## 🚀 Summary

Server failed to start with `'TW_VITE_DEV_SERVER_URL' expected a map or struct, got "string"`. The root cause is that `mapstructure.StringToURLHookFunc` only targets `*url.URL`. Because `config.Default()` pre-populates `ViteDevServerURL` with a non-nil `*url.URL` before `dotenv.Load` runs, mapstructure dereferences the pointer and passes `url.URL` (the struct) as the target type, so the built-in hook never fires and the default struct decoder rejects the string input.

## ✏️ Changes

- Replaced `mapstructure.StringToURLHookFunc()` with a local `stringToURLFunc` in `server/pkg/dotenv/dotenv.go` that handles both `*url.URL` and `url.URL` target types.
- Extended the existing URL decode test with an "overrides prepopulated pointer" case that reproduces the failure pre-fix.