### PR TITLE
docs(`CLAUDE.md`): require PR template for pull request descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,3 +85,7 @@ Use `want/got` style:
 - Don't list implementation details (e.g. individual functions, internal mechanisms) - keep it high level
 - Make logical, incremental commits rather than one large commit
 - Always create a feature branch before starting work
+
+## Pull Request Conventions
+
+- Always use the PR template at `.github/PULL_REQUEST_TEMPLATE.md` for the PR description. Fill in every section of the template; do not substitute an ad-hoc structure


### PR DESCRIPTION
## 🚀 Summary

Codify that PR descriptions must use the project template at `.github/PULL_REQUEST_TEMPLATE.md`. Without this in `CLAUDE.md`, Claude Code defaults to an ad-hoc "Summary / Test plan" layout instead of the repo's template.

## ✏️ Changes

- Added a **Pull Request Conventions** section to `CLAUDE.md` instructing that the template at `.github/PULL_REQUEST_TEMPLATE.md` must be used for every PR, with all sections filled in.