### PR TITLE
docs(`CLAUDE.md`): refresh style, tests, and tooling notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,19 +17,17 @@ A unified platform that consolidates teacher-facing applications into day-to-day
 
 ## Architecture
 
-- Monorepo: Go backend + React frontend
-- Config via environment variables with `TW_` prefix (see `.env.example`)
-- Go HTTP server uses standard library `net/http` — no framework
+- Monorepo: Go backend + React frontend.
+- Env vars prefixed `TW_` (see `.env.example`).
+- Go HTTP server uses stdlib `net/http`; no framework.
 
 ## Build & Run Commands
 
-### Dev
-
 ```bash
-pnpm dev:all                        # Run the TW application
+pnpm dev:all                          # Run server + web together
 ```
 
-### Go
+### Server
 
 ```bash
 go build -o build/tw ./server/cmd/tw  # Build binary
@@ -41,21 +39,61 @@ go test -run TestName ./path/to/pkg   # Run a specific test
 golangci-lint run                     # Static analysis
 ```
 
-### Frontend
+### Web
 
 ```bash
-pnpm install                        # Install dependencies
-pnpm dev                            # Run Vite dev server
-pnpm build                          # Build production bundle
-pnpm lint                           # Run ESLint
-pnpm format                         # Run Prettier
+pnpm dev                              # Run Vite dev server
+pnpm build                            # Build production bundle
+pnpm lint                             # Run oxlint
+pnpm format                           # Run oxfmt
 ```
 
 ## Formatting & Linting
 
-- Go: `golangci-lint run` (gofmt + goimports)
-- TS/JS: `pnpm lint` (ESLint), `pnpm format` (Prettier)
-- Pre-commit: Husky + lint-staged runs Prettier and ESLint on staged files
+- Go: `golangci-lint run` (gofmt + goimports).
+- TS/JS: `pnpm lint` (oxlint), `pnpm format` (oxfmt).
+- Pre-commit: Husky + lint-staged run oxfmt and oxlint on staged files.
+
+## Style
+
+- Don't use em-dashes (`—`). Use colons, parentheses, or separate sentences.
+
+### Go
+
+#### Struct literals
+
+Use **keyed struct literals** (field names), even when every field is set. Positional literals break silently on field add/reorder and force readers to cross-reference the type.
+
+- Yes: `User{Name: "a", Age: 1}`
+- No: `User{"a", 1}`
+- Applies to table-driven test cases too: list each field by name.
+
+#### Type comments
+
+- Start with the type name; full sentence.
+- Describe what the type represents and its role in the package.
+- Document non-obvious semantics: zero-value use, invariants, ownership, mutability, concurrency, error meaning.
+- Skip field or implementation restatements; include only what callers can't infer from the definition.
+
+#### Method comments
+
+- Start with the method name; full sentence.
+- Describe from the caller's view: what it does, not how.
+- Document non-obvious semantics: nil, mutation, errors, ordering, concurrency, zero-value.
+- Skip signature restatements; include only what callers can't infer from the code.
+- Add an example when the method is central, tricky, or easier shown than told.
+
+#### Field comments
+
+Describe the field, not surrounding workflow. Start with `contains` (slices/maps), `reports whether` (bools), `is`, or `holds`. If the field name implies the noun, focus on the qualifier.
+
+#### Code comments
+
+Comment _why_, not _what_; self-explanatory code needs no comment.
+
+- Add comments only for non-obvious logic, invariants, or edge cases.
+- Place comments above a logical block, not on every line.
+- Tie comments to stable intent so they don't rot when implementation changes.
 
 ## Test Conventions
 
@@ -63,36 +101,36 @@ pnpm format                         # Run Prettier
 
 #### Structure
 
-- Parent test + subtests. Small pure functions get standalone tests without subtests
+- One parent test per function/method under test, named after it. All cases live as `t.Run` subtests inside the parent.
+  - Top-level functions: `Test<Func>` (e.g. `TestParse`).
+  - Struct methods: `Test<Type>_<Method>` (e.g. `TestReader_Read`).
+- Small pure helpers get standalone tests without subtests.
+- Related subtests can be grouped under an intermediate `t.Run` (e.g. `t.Run("rejects invalid input", ...)`); table-driven cases inside use only the distinguishing trait (the group name provides the verb).
 
 #### Naming
 
-- Outcome first, optionally followed by scenario: `"returns error on timeout"`, `"rejects invalid key"`
-- Table-driven subtests use just the distinguishing trait: `"missing XXX"`, `"wrong status code"`. The parent test name provides the verb context
+- Parent function: `Test<Func>` or `Test<Type>_<Method>`, no extra suffix.
+- Subtest names start with the outcome, optionally followed by the scenario: `"returns error on timeout"`, `"rejects invalid key"`.
+- Table-driven cases inside a grouping `t.Run` use just the distinguishing trait: `"missing XXX"`, `"wrong status code"`.
 
 #### Assertions
 
 Use `want/got` style:
 
-- Error checks: `t.Fatalf("want nil, got: %v", err)` or `t.Fatal("want: err, got: nil)`
+- Error checks: `t.Fatalf("want nil, got: %v", err)` or `t.Fatal("want: err, got: nil")`
 - Field checks: `t.Errorf("want name: %q, got: %q", want, got)`
 - Containment: `t.Errorf("want err containing %q, got: %v", substr, err)`
-- When `got` isn't already captured, use an `if` initialiser: `if want, got := "XXX", resp.Header.Get("X-XXX"); want != got { ... }`
-
-### TypeScript
-
-- No frontend tests yet
+- If `got` isn't captured, use an `if` initialiser: `if want, got := "XXX", resp.Header.Get("X-XXX"); want != got { ... }`
 
 ## Commit Conventions
 
-- Keep commit messages to a single summary line - no multi-line body/description. Details go in the PR description instead
-- Use conventional commit format (e.g. `feat:`, `fix:`, `test:`, `docs:`)
-- Use backticks around file names and variables names in commit message
-- Be specific - name the things being changed rather than using vague descriptions
-- Don't list implementation details (e.g. individual functions, internal mechanisms) - keep it high level
-- Make logical, incremental commits rather than one large commit
-- Always create a feature branch before starting work
+- Single summary line only (no multi-line body); details go in the PR description.
+- Use conventional commit format (e.g. `feat:`, `fix:`, `test:`, `docs:`).
+- Backtick file and variable names in commit messages.
+- Be specific: name the things being changed, not vague descriptions.
+- Keep it high level; don't list implementation details (e.g. individual functions).
+- Make logical, incremental commits.
 
 ## Pull Request Conventions
 
-- Always use the PR template at `.github/PULL_REQUEST_TEMPLATE.md` for the PR description. Fill in every section of the template; do not substitute an ad-hoc structure
+- Use `.github/PULL_REQUEST_TEMPLATE.md` for the description; fill every section.


### PR DESCRIPTION
## 🚀 Summary

Brings `CLAUDE.md` guidance up to date on two fronts:

- **Convention drift**: Tightens prose throughout and adds Go style rules (struct literals, type/method/field/code comments) plus fleshed-out test conventions (parent/subtest naming, grouped `t.Run` pattern). These conventions already inform how we write Go here but weren't written down.
- **Stale tooling**: The frontend migrated from ESLint/Prettier to oxlint/oxfmt, but the doc still referenced the old tools. Contributors (and Claude) were getting incorrect commands.

## ✏️ Changes

- Add `## Style` section: em-dash rule, plus Go-specific rules for struct literals and type/method/field/code comments.
- Expand `## Test Conventions` → `### Go`: parent/subtest naming (`Test<Func>`, `Test<Type>_<Method>`), grouped `t.Run` pattern, assertions block (fixes a missing closing quote on the `Fatal` example).
- Remove the `### TypeScript` test subsection (no frontend tests yet).
- Switch frontend tooling notes from ESLint/Prettier to oxlint/oxfmt in the Web commands block and Formatting & Linting section.
- Tighten Architecture, Build & Run, Commit Conventions, and Pull Request Conventions to short single-line bullets.
- Replace an em-dash in the Architecture section with a colon.